### PR TITLE
Add camera integration: face recognition, gesture detection, webcam UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ GitHub Actions workflow (`.github/workflows/build.yml`): triggers on release cre
 
 ```
 electron/main.ts          — Multi-window Electron entry (main + character window)
-electron/preload.ts       — contextBridge API (platform + vision + characterWindow IPC bridge)
+electron/preload.ts       — contextBridge API (platform + characterWindow IPC bridge)
 src/api/client.ts         — Axios + WebSocket singleton; streaming via wsManager
 src/api/types.ts          — TypeScript interfaces for API
 src/components/
@@ -43,7 +43,7 @@ src/store/
   authStore.ts            — Auth state, login/register/logout, token persistence
   conversationStore.ts    — Conversations, messages (paginated 50/page), models
   agentStore.ts           — Agent list (filtered, no Administrator), selected agent ID (persisted)
-  visionStore.ts          — Zustand singleton: vision pipeline control (webcam selection, ffmpeg→RTSP, face/pose/hands toggles, WebSocket vision_result listener + gesture IPC forwarding). Used by both FacesWindow and ChatWidget camera toggle.
+  visionStore.ts          — Zustand singleton: vision pipeline control (getUserMedia webcam capture, frame upload at 3 FPS via WebSocket, face/pose/hands toggles, WebSocket vision_result listener + gesture IPC forwarding). Used by both FacesWindow and ChatWidget camera toggle.
 src/CharacterWindowApp.tsx — Minimal IPC-driven renderer for separate character window (no auth/stores)
 src/videocall/            — Character animation engine (rendered in separate Electron window via IPC)
   types.ts                — PoseConfig, PatchInfo, PoseTree, AnimationNode/Edge/EdgeTransition, TransitionCondition (random/thinking/gesture), AnimationSettings, CharacterConfig, migrateEdgeToTransitions()
@@ -130,7 +130,6 @@ Separate Electron window (toggleable via Face icon in top bar). Opens as indepen
 - `character:gesture-update` — `{ gestures: string[] }` forwarded from vision pipeline to trigger pose transitions
 - `character:window-closed` — main process → main renderer when user closes character window
 - `character:open-window` / `character:close-window` — renderer invokes main process to create/destroy window
-- `vision:start` / `vision:stop` / `vision:list-webcams` — renderer invokes main process to spawn/kill ffmpeg webcam→RTSP capture
 
 **Canvas compositing**: Base image + diff patches (eyes, mouth) at stored positions. Blink: configurable random interval state machine (default 2-6s). Breathing: sine wave vertical offset (configurable amplitude/period). Lip sync: audio amplitude → mouth patch index. Per-agent character configs stored in backend DB as JSON. **State machine**: IDLE (blink/breathing/mouth + event listening) → TRANSITIONING (playing edge video on canvas, all events ignored) → IDLE (switch to target pose, apply node settings, reset timers). During transitions no events are processed; random timers start fresh when arriving at a node. **Multi-transition edges**: Each directed edge (`AnimationEdge`) contains `transitions: EdgeTransition[]` — multiple transitions per edge, each with its own condition, video list, and playback rate. One edge per directed node pair (deterministic ID: `edge-{source}-{target}`). Timer keys use `${edge.id}:${transitionIndex}`. Legacy edges (single condition/video_urls/playback_rate) auto-migrated on load via `migrateEdgeToTransitions()`. Transition conditions: `random` (timer-based), `thinking` (fires when `isThinking` matches `condition.value`), `gesture` (fires when detected gesture matches `condition.value`, e.g. "wave", "thumbs_up", "peace_sign"). `isThinking` is a live variable observed each frame while idle — no edge detection. If multiple transitions satisfy simultaneously, one is chosen at random. `isThinking` piggybacked on amplitude IPC channel at ~30fps. **Per-node animation settings**: `AnimationNode.animation_settings` (optional) configures breathing (enabled/amplitude/period) and blink timing (min/max interval, close/hold/open duration). Applied via `applySettings()` on each pose switch. UI: sliders in PoseNodeEditor Preview step.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ GitHub Actions workflow (`.github/workflows/build.yml`): triggers on release cre
 
 ```
 electron/main.ts          — Multi-window Electron entry (main + character window)
-electron/preload.ts       — contextBridge API (platform + characterWindow IPC bridge)
+electron/preload.ts       — contextBridge API (platform + vision + characterWindow IPC bridge)
 src/api/client.ts         — Axios + WebSocket singleton; streaming via wsManager
 src/api/types.ts          — TypeScript interfaces for API
 src/components/
@@ -30,6 +30,7 @@ src/components/
   ChatWidget.tsx           — Chat UI with streaming, TTS auto-play, image attach, pagination, IPC bridge to character window
   MessageBubble.tsx        — Individual bubble: role styling, thinking collapse, TTS, resend/delete
   AgentsWindow.tsx         — Agent CRUD with tool assignment + character config button
+  FacesWindow.tsx          — Face identity CRUD, webcam vision controls, live recognition display
   CharacterConfigDialog.tsx — React Flow graph editor: multi-pose nodes, edges with transition videos, conditions
   PoseNodeEditor.tsx        — Extracted 3-step stepper sub-dialog for editing individual pose nodes
   EdgeEditor.tsx            — Transition edge editor: video upload, condition config (random timer)
@@ -42,9 +43,10 @@ src/store/
   authStore.ts            — Auth state, login/register/logout, token persistence
   conversationStore.ts    — Conversations, messages (paginated 50/page), models
   agentStore.ts           — Agent list (filtered, no Administrator), selected agent ID (persisted)
+  visionStore.ts          — Zustand singleton: vision pipeline control (webcam selection, ffmpeg→RTSP, face/pose/hands toggles, WebSocket vision_result listener + gesture IPC forwarding). Used by both FacesWindow and ChatWidget camera toggle.
 src/CharacterWindowApp.tsx — Minimal IPC-driven renderer for separate character window (no auth/stores)
 src/videocall/            — Character animation engine (rendered in separate Electron window via IPC)
-  types.ts                — PoseConfig, PatchInfo, PoseTree, AnimationNode/Edge, TransitionCondition, AnimationSettings, CharacterConfig
+  types.ts                — PoseConfig, PatchInfo, PoseTree, AnimationNode/Edge/EdgeTransition, TransitionCondition (random/thinking/gesture), AnimationSettings, CharacterConfig, migrateEdgeToTransitions()
   CharacterRenderer.tsx   — React wrapper around CanvasCompositor (accepts PoseTree, amplitude via ref)
   engine/
     CanvasCompositor.ts   — 60fps render: blink + breathing + mouth + pose tree state machine (idle→transitioning→idle), edge timers, video transitions, configurable AnimationSettings
@@ -114,24 +116,29 @@ src/config.ts             — API URL config (reads dynamically from storage)
 - `GET /character-assets/{agent_id}/{pose_id}/{filename}` — Serve pose asset (base/patch image, no-cache)
 - `GET /character-assets/{agent_id}/edges/{edge_id}` — Serve transition video (no-cache)
 - `PATCH /character-assets/{agent_id}/character-config` — Update pose tree config (cleans up orphaned assets incl. videos)
+- `GET /faces`, `POST /faces`, `GET /faces/{id}`, `DELETE /faces/{id}` — Face identity CRUD
+- `POST /faces/{id}/photos`, `DELETE /faces/{id}/photos/{photo_id}` — Face photo management
+- `GET /faces/{id}/photos/{photo_id}/image` — Serve face photo image
 
 ## Character Animation
 
 Separate Electron window (toggleable via Face icon in top bar). Opens as independent, resizable BrowserWindow — same Vite bundle routed via `?window=character` query param → `CharacterWindowApp` (no auth, no stores, purely IPC-driven).
 
 **IPC channels** (main renderer → main process → character renderer):
-- `character:amplitude` — `{ amplitude, isPlaying }` at ~30fps via setInterval
+- `character:amplitude` — `{ amplitude, isPlaying, isThinking }` at ~30fps via setInterval
 - `character:agents-update` — `{ agents: [{id, name, poseTree}], activeAgentId }` on agent map or active agent change
+- `character:gesture-update` — `{ gestures: string[] }` forwarded from vision pipeline to trigger pose transitions
 - `character:window-closed` — main process → main renderer when user closes character window
 - `character:open-window` / `character:close-window` — renderer invokes main process to create/destroy window
+- `vision:start` / `vision:stop` / `vision:list-webcams` — renderer invokes main process to spawn/kill ffmpeg webcam→RTSP capture
 
-**Canvas compositing**: Base image + diff patches (eyes, mouth) at stored positions. Blink: configurable random interval state machine (default 2-6s). Breathing: sine wave vertical offset (configurable amplitude/period). Lip sync: audio amplitude → mouth patch index. Per-agent character configs stored in backend DB as JSON. **State machine**: IDLE (blink/breathing/mouth + event listening) → TRANSITIONING (playing edge video on canvas, all events ignored) → IDLE (switch to target pose, apply node settings, reset timers). During transitions no events are processed; random timers start fresh when arriving at a node. Edge conditions: `random` (timer-based), `thinking` (fires when `isThinking` matches `condition.value`). `isThinking` is a live variable observed each frame while idle — no edge detection. If multiple edges satisfy simultaneously, one is chosen at random. `isThinking` piggybacked on amplitude IPC channel at ~30fps. **Per-node animation settings**: `AnimationNode.animation_settings` (optional) configures breathing (enabled/amplitude/period) and blink timing (min/max interval, close/hold/open duration). Applied via `applySettings()` on each pose switch. UI: sliders in PoseNodeEditor Preview step. **Per-edge playback rate**: `AnimationEdge.playback_rate` (optional, default 1.0) controls transition video speed. UI: slider in EdgeEditor.
+**Canvas compositing**: Base image + diff patches (eyes, mouth) at stored positions. Blink: configurable random interval state machine (default 2-6s). Breathing: sine wave vertical offset (configurable amplitude/period). Lip sync: audio amplitude → mouth patch index. Per-agent character configs stored in backend DB as JSON. **State machine**: IDLE (blink/breathing/mouth + event listening) → TRANSITIONING (playing edge video on canvas, all events ignored) → IDLE (switch to target pose, apply node settings, reset timers). During transitions no events are processed; random timers start fresh when arriving at a node. **Multi-transition edges**: Each directed edge (`AnimationEdge`) contains `transitions: EdgeTransition[]` — multiple transitions per edge, each with its own condition, video list, and playback rate. One edge per directed node pair (deterministic ID: `edge-{source}-{target}`). Timer keys use `${edge.id}:${transitionIndex}`. Legacy edges (single condition/video_urls/playback_rate) auto-migrated on load via `migrateEdgeToTransitions()`. Transition conditions: `random` (timer-based), `thinking` (fires when `isThinking` matches `condition.value`), `gesture` (fires when detected gesture matches `condition.value`, e.g. "wave", "thumbs_up", "peace_sign"). `isThinking` is a live variable observed each frame while idle — no edge detection. If multiple transitions satisfy simultaneously, one is chosen at random. `isThinking` piggybacked on amplitude IPC channel at ~30fps. **Per-node animation settings**: `AnimationNode.animation_settings` (optional) configures breathing (enabled/amplitude/period) and blink timing (min/max interval, close/hold/open duration). Applied via `applySettings()` on each pose switch. UI: sliders in PoseNodeEditor Preview step.
 
 **Asset pipeline**: AI-generated base → inpainted variants → backend OpenCV diff → cropped patch PNGs. Assets stored in folder structure: `data/character_assets/{agent_id}/{pose_id}/base.png`, `{part}_{index}.png`; videos in `{agent_id}/edges/{edge_id}.mp4|.webm`. Re-uploading overwrites without changing URLs. Orphaned assets cleaned up on config save.
 
 **Data flow**: ChatWidget fetches agent character_config on agent switch during streaming → builds agentMap (with poseTree, not poseConfig) + activeAgentId → sends via IPC to character window. TTS amplitude ref read by setInterval(33ms) and sent via IPC. CharacterWindowApp receives IPC data and renders CharacterRenderer components. CharacterRenderer calls `compositor.loadPoseTree()` to load all poses + initialize edge timers. CanvasCompositor reads amplitude at 60fps from local ref.
 
-**Graph editor (CharacterConfigDialog)**: React Flow (@xyflow/react) canvas with custom `poseNode` nodes. Nodes represent poses; edges represent transitions with optional video clips and conditions. Sub-dialogs: PoseNodeEditor (3-step stepper for base/patches/preview), EdgeEditor (video upload + condition config). Right-click node for context menu (Set as Default, Edit, Delete). Conversion: poseTreeToReactFlow/reactFlowToPoseTree.
+**Graph editor (CharacterConfigDialog)**: React Flow (@xyflow/react) canvas with custom `poseNode` nodes. Nodes represent poses; one edge per directed node pair containing multiple transitions. Connecting an existing pair opens the edge editor instead of creating a duplicate. Sub-dialogs: PoseNodeEditor (3-step stepper for base/patches/preview), EdgeEditor (multi-transition cards with per-transition condition/video/playback rate). Right-click node for context menu (Set as Default, Edit, Delete). Conversion: poseTreeToReactFlow/reactFlowToPoseTree. Video upload naming: `${edge.id}_t${transitionIdx}_${videoIdx}`.
 
 ## Storage Keys (localStorage)
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,5 +1,4 @@
 import { app, BrowserWindow, ipcMain } from 'electron';
-import { spawn, ChildProcess } from 'child_process';
 import path from 'path';
 
 // Set custom cache path to avoid permission issues on Windows
@@ -7,7 +6,6 @@ app.setPath('userData', path.join(app.getPath('appData'), 'kurisu-assistant'));
 
 let mainWindow: BrowserWindow | null = null;
 let characterWindow: BrowserWindow | null = null;
-let ffmpegProcess: ChildProcess | null = null;
 
 function createWindow() {
   mainWindow = new BrowserWindow({
@@ -118,97 +116,6 @@ ipcMain.on('character:gesture-update', (_event, data) => {
   if (characterWindow && !characterWindow.isDestroyed()) {
     characterWindow.webContents.send('character:gesture-update', data);
   }
-});
-
-// --- Vision (ffmpeg webcam → RTSP) ---
-
-ipcMain.handle('vision:start', (_event, webcamName: string, rtspUrl: string) => {
-  // Kill existing ffmpeg process
-  if (ffmpegProcess) {
-    ffmpegProcess.kill('SIGTERM');
-    ffmpegProcess = null;
-  }
-
-  // Strip browser-style suffixes like " (046d:0825)" from webcam label
-  const dshowName = webcamName.replace(/\s*\([0-9a-f]{4}:[0-9a-f]{4}\)\s*$/i, '');
-
-  // Spawn ffmpeg to capture webcam and push to RTSP server via TCP
-  const args = [
-    '-f', 'dshow',
-    '-rtbufsize', '100M',
-    '-i', `video=${dshowName}`,
-    '-c:v', 'libx264',
-    '-preset', 'ultrafast',
-    '-tune', 'zerolatency',
-    '-pix_fmt', 'yuv420p',
-    '-rtsp_transport', 'tcp',
-    '-f', 'rtsp',
-    rtspUrl,
-  ];
-
-  ffmpegProcess = spawn('ffmpeg', args);
-
-  ffmpegProcess.stderr?.on('data', (data: Buffer) => {
-    console.log('[Vision] ffmpeg:', data.toString().trim());
-  });
-
-  ffmpegProcess.on('error', (error) => {
-    console.error('[Vision] ffmpeg process error:', error);
-    ffmpegProcess = null;
-  });
-
-  ffmpegProcess.on('close', () => {
-    ffmpegProcess = null;
-  });
-
-  return { status: 'started' };
-});
-
-ipcMain.handle('vision:stop', () => {
-  if (ffmpegProcess) {
-    ffmpegProcess.kill('SIGTERM');
-    ffmpegProcess = null;
-  }
-  return { status: 'stopped' };
-});
-
-ipcMain.handle('vision:list-webcams', async () => {
-  // Use ffmpeg to list DirectShow devices on Windows
-  return new Promise<string[]>((resolve) => {
-    const proc = spawn('ffmpeg', ['-list_devices', 'true', '-f', 'dshow', '-i', 'dummy']);
-
-    let stderr = '';
-    proc.stderr?.on('data', (data: Buffer) => {
-      stderr += data.toString();
-    });
-
-    proc.on('close', () => {
-      const webcams: string[] = [];
-      const lines = stderr.split('\n');
-      let inVideoSection = false;
-      for (const line of lines) {
-        if (line.includes('DirectShow video devices')) {
-          inVideoSection = true;
-          continue;
-        }
-        if (line.includes('DirectShow audio devices')) {
-          inVideoSection = false;
-          continue;
-        }
-        if (inVideoSection) {
-          const match = line.match(/"([^"]+)"/);
-          if (match && !line.includes('Alternative name')) {
-            webcams.push(match[1]);
-          }
-        }
-      }
-      resolve(webcams);
-    });
-
-    proc.on('error', () => {
-      resolve([]);
-    });
-  });
 });
 
 // --- App Lifecycle ---

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, ipcMain } from 'electron';
+import { spawn, ChildProcess } from 'child_process';
 import path from 'path';
 
 // Set custom cache path to avoid permission issues on Windows
@@ -6,6 +7,7 @@ app.setPath('userData', path.join(app.getPath('appData'), 'kurisu-assistant'));
 
 let mainWindow: BrowserWindow | null = null;
 let characterWindow: BrowserWindow | null = null;
+let ffmpegProcess: ChildProcess | null = null;
 
 function createWindow() {
   mainWindow = new BrowserWindow({
@@ -109,6 +111,104 @@ ipcMain.on('character:ready', () => {
   if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.webContents.send('character:ready');
   }
+});
+
+// IPC relay: gesture updates from main renderer → character renderer
+ipcMain.on('character:gesture-update', (_event, data) => {
+  if (characterWindow && !characterWindow.isDestroyed()) {
+    characterWindow.webContents.send('character:gesture-update', data);
+  }
+});
+
+// --- Vision (ffmpeg webcam → RTSP) ---
+
+ipcMain.handle('vision:start', (_event, webcamName: string, rtspUrl: string) => {
+  // Kill existing ffmpeg process
+  if (ffmpegProcess) {
+    ffmpegProcess.kill('SIGTERM');
+    ffmpegProcess = null;
+  }
+
+  // Strip browser-style suffixes like " (046d:0825)" from webcam label
+  const dshowName = webcamName.replace(/\s*\([0-9a-f]{4}:[0-9a-f]{4}\)\s*$/i, '');
+
+  // Spawn ffmpeg to capture webcam and push to RTSP server via TCP
+  const args = [
+    '-f', 'dshow',
+    '-rtbufsize', '100M',
+    '-i', `video=${dshowName}`,
+    '-c:v', 'libx264',
+    '-preset', 'ultrafast',
+    '-tune', 'zerolatency',
+    '-pix_fmt', 'yuv420p',
+    '-rtsp_transport', 'tcp',
+    '-f', 'rtsp',
+    rtspUrl,
+  ];
+
+  ffmpegProcess = spawn('ffmpeg', args);
+
+  ffmpegProcess.stderr?.on('data', (data: Buffer) => {
+    console.log('[Vision] ffmpeg:', data.toString().trim());
+  });
+
+  ffmpegProcess.on('error', (error) => {
+    console.error('[Vision] ffmpeg process error:', error);
+    ffmpegProcess = null;
+  });
+
+  ffmpegProcess.on('close', () => {
+    ffmpegProcess = null;
+  });
+
+  return { status: 'started' };
+});
+
+ipcMain.handle('vision:stop', () => {
+  if (ffmpegProcess) {
+    ffmpegProcess.kill('SIGTERM');
+    ffmpegProcess = null;
+  }
+  return { status: 'stopped' };
+});
+
+ipcMain.handle('vision:list-webcams', async () => {
+  // Use ffmpeg to list DirectShow devices on Windows
+  return new Promise<string[]>((resolve) => {
+    const proc = spawn('ffmpeg', ['-list_devices', 'true', '-f', 'dshow', '-i', 'dummy']);
+
+    let stderr = '';
+    proc.stderr?.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    proc.on('close', () => {
+      const webcams: string[] = [];
+      const lines = stderr.split('\n');
+      let inVideoSection = false;
+      for (const line of lines) {
+        if (line.includes('DirectShow video devices')) {
+          inVideoSection = true;
+          continue;
+        }
+        if (line.includes('DirectShow audio devices')) {
+          inVideoSection = false;
+          continue;
+        }
+        if (inVideoSection) {
+          const match = line.match(/"([^"]+)"/);
+          if (match && !line.includes('Alternative name')) {
+            webcams.push(match[1]);
+          }
+        }
+      }
+      resolve(webcams);
+    });
+
+    proc.on('error', () => {
+      resolve([]);
+    });
+  });
 });
 
 // --- App Lifecycle ---

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -3,6 +3,12 @@ import { contextBridge, ipcRenderer } from 'electron';
 contextBridge.exposeInMainWorld('electron', {
   platform: process.platform,
 
+  vision: {
+    start: (webcamName: string, rtspUrl: string) => ipcRenderer.invoke('vision:start', webcamName, rtspUrl),
+    stop: () => ipcRenderer.invoke('vision:stop'),
+    listWebcams: () => ipcRenderer.invoke('vision:list-webcams'),
+  },
+
   characterWindow: {
     open: () => ipcRenderer.invoke('character:open-window'),
     close: () => ipcRenderer.invoke('character:close-window'),
@@ -26,6 +32,14 @@ contextBridge.exposeInMainWorld('electron', {
       const handler = () => cb();
       ipcRenderer.on('character:window-closed', handler);
       return () => { ipcRenderer.removeListener('character:window-closed', handler); };
+    },
+
+    sendGestureUpdate: (data: { gestures: string[] }) =>
+      ipcRenderer.send('character:gesture-update', data),
+    onGestureUpdate: (cb: (data: { gestures: string[] }) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, data: { gestures: string[] }) => cb(data);
+      ipcRenderer.on('character:gesture-update', handler);
+      return () => { ipcRenderer.removeListener('character:gesture-update', handler); };
     },
 
     signalReady: () => ipcRenderer.send('character:ready'),

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -3,12 +3,6 @@ import { contextBridge, ipcRenderer } from 'electron';
 contextBridge.exposeInMainWorld('electron', {
   platform: process.platform,
 
-  vision: {
-    start: (webcamName: string, rtspUrl: string) => ipcRenderer.invoke('vision:start', webcamName, rtspUrl),
-    stop: () => ipcRenderer.invoke('vision:stop'),
-    listWebcams: () => ipcRenderer.invoke('vision:list-webcams'),
-  },
-
   characterWindow: {
     open: () => ipcRenderer.invoke('character:open-window'),
     close: () => ipcRenderer.invoke('character:close-window'),

--- a/src/CharacterWindowApp.tsx
+++ b/src/CharacterWindowApp.tsx
@@ -13,6 +13,7 @@ export const CharacterWindowApp: React.FC = () => {
   const [activeAgentId, setActiveAgentId] = useState<number | null>(null);
   const amplitudeRef = useRef<AmplitudeState>({ amplitude: 0, isPlaying: false, isThinking: false });
   const silentRef = useRef<AmplitudeState>({ amplitude: 0, isPlaying: false, isThinking: false });
+  const gesturesRef = useRef<string[]>([]);
 
   useEffect(() => {
     const api = window.electron?.characterWindow;
@@ -48,12 +49,17 @@ export const CharacterWindowApp: React.FC = () => {
       });
     });
 
+    const cleanupGestures = api.onGestureUpdate((data) => {
+      gesturesRef.current = data.gestures;
+    });
+
     // Signal to main renderer that listeners are ready — triggers initial data push
     api.signalReady();
 
     return () => {
       cleanupAmplitude();
       cleanupAgents();
+      cleanupGestures();
     };
   }, []);
 
@@ -109,6 +115,7 @@ export const CharacterWindowApp: React.FC = () => {
               <CharacterRenderer
                 poseTree={entry.poseTree}
                 amplitudeRef={activeAgentId === id ? amplitudeRef : silentRef}
+                gesturesRef={activeAgentId === id || activeAgentId === null ? gesturesRef : undefined}
               />
             ) : (
               <span style={{ color: 'rgba(0,0,0,0.3)', fontSize: 14 }}>

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -20,6 +20,8 @@ import type {
   ComputePatchResponseDTO,
   UploadVideoResponseDTO,
   CharacterConfigDTO,
+  FaceIdentity,
+  FaceIdentityDetail,
 } from './types';
 
 class APIClient {
@@ -440,6 +442,58 @@ class APIClient {
       { headers: this.getHeaders() }
     );
     return response.data;
+  }
+  // Face Recognition Methods
+
+  async listFaces(): Promise<FaceIdentity[]> {
+    const response = await this.client.get<FaceIdentity[]>('/faces', {
+      headers: this.getHeaders(),
+    });
+    return response.data;
+  }
+
+  async createFace(name: string, photo: File): Promise<any> {
+    const formData = new FormData();
+    formData.append('photo', photo);
+
+    const response = await this.client.post('/faces', formData, {
+      headers: this.getHeaders(),
+      params: { name },
+    });
+    return response.data;
+  }
+
+  async getFace(id: number): Promise<FaceIdentityDetail> {
+    const response = await this.client.get<FaceIdentityDetail>(`/faces/${id}`, {
+      headers: this.getHeaders(),
+    });
+    return response.data;
+  }
+
+  async deleteFace(id: number): Promise<void> {
+    await this.client.delete(`/faces/${id}`, {
+      headers: this.getHeaders(),
+    });
+  }
+
+  async addFacePhoto(id: number, photo: File): Promise<any> {
+    const formData = new FormData();
+    formData.append('photo', photo);
+
+    const response = await this.client.post(`/faces/${id}/photos`, formData, {
+      headers: this.getHeaders(),
+    });
+    return response.data;
+  }
+
+  async deleteFacePhoto(identityId: number, photoId: number): Promise<void> {
+    await this.client.delete(`/faces/${identityId}/photos/${photoId}`, {
+      headers: this.getHeaders(),
+    });
+  }
+
+  getFacePhotoUrl(identityId: number, photoId: number): string {
+    return `${config.apiBaseUrl}/faces/${identityId}/photos/${photoId}/image`;
   }
 }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -166,3 +166,46 @@ export interface ToolsResponse {
   mcp_tools: Tool[];
   builtin_tools: Tool[];
 }
+
+// Face recognition types
+
+export interface FaceIdentity {
+  id: number;
+  name: string;
+  photo_count: number;
+  created_at: string;
+}
+
+export interface FaceIdentityDetail {
+  id: number;
+  name: string;
+  created_at: string;
+  photos: FacePhoto[];
+}
+
+export interface FacePhoto {
+  id: number;
+  photo_uuid: string;
+  url: string;
+  created_at?: string;
+}
+
+// Vision result types (from WebSocket)
+
+export interface VisionFace {
+  identity_id: number | null;
+  name: string;
+  confidence: number;
+  bbox: number[];
+}
+
+export interface VisionGesture {
+  gesture: string;
+  confidence: number;
+}
+
+export interface VisionResult {
+  faces: VisionFace[];
+  gestures: VisionGesture[];
+  debug_frame?: string;
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -207,5 +207,4 @@ export interface VisionGesture {
 export interface VisionResult {
   faces: VisionFace[];
   gestures: VisionGesture[];
-  debug_frame?: string;
 }

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -9,11 +9,14 @@ export type EventType =
   | 'chat_request'
   | 'tool_approval_response'
   | 'cancel'
+  | 'vision_start'
+  | 'vision_stop'
   | 'stream_chunk'
   | 'tool_approval_request'
   | 'agent_switch'
   | 'done'
   | 'error'
+  | 'vision_result'
   | 'reconnected';
 
 // Base event interface
@@ -35,6 +38,15 @@ export interface ChatRequestEvent extends BaseEvent {
 
 export interface CancelEvent extends BaseEvent {
   type: 'cancel';
+}
+
+export interface VisionStartEvent extends BaseEvent {
+  type: 'vision_start';
+  rtsp_url: string;
+}
+
+export interface VisionStopEvent extends BaseEvent {
+  type: 'vision_stop';
 }
 
 // Server -> Client events
@@ -82,12 +94,28 @@ export interface ToolApprovalRequestEvent extends BaseEvent {
   risk_level: string;
 }
 
+export interface VisionResultEvent extends BaseEvent {
+  type: 'vision_result';
+  faces: Array<{
+    identity_id: number | null;
+    name: string;
+    confidence: number;
+    bbox: number[];
+  }>;
+  gestures: Array<{
+    gesture: string;
+    confidence: number;
+  }>;
+  debug_frame?: string; // Base64 JPEG with annotations
+}
+
 export type ServerEvent =
   | StreamChunkEvent
   | AgentSwitchEvent
   | DoneEvent
   | ErrorEvent
-  | ToolApprovalRequestEvent;
+  | ToolApprovalRequestEvent
+  | VisionResultEvent;
 
 type EventHandler<T = ServerEvent> = (event: T) => void;
 
@@ -213,7 +241,7 @@ class WebSocketManager {
   /**
    * Send an event to the server.
    */
-  send(event: Partial<ChatRequestEvent> | Partial<CancelEvent>) {
+  send(event: Partial<ChatRequestEvent> | Partial<CancelEvent> | Partial<VisionStartEvent> | Partial<VisionStopEvent>) {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       throw new Error('WebSocket not connected');
     }
@@ -248,6 +276,33 @@ class WebSocketManager {
       agent_id: agentId,
       images,
     });
+  }
+
+  /**
+   * Send a vision start request.
+   */
+  async sendVisionStart(rtspUrl: string, options?: {
+    enable_face?: boolean;
+    enable_pose?: boolean;
+    enable_hands?: boolean;
+  }): Promise<void> {
+    await this.connect();
+    this.send({
+      type: 'vision_start',
+      rtsp_url: rtspUrl,
+      enable_face: options?.enable_face ?? true,
+      enable_pose: options?.enable_pose ?? true,
+      enable_hands: options?.enable_hands ?? true,
+    });
+  }
+
+  /**
+   * Send a vision stop request.
+   */
+  sendVisionStop() {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.send({ type: 'vision_stop' });
+    }
   }
 
   /**

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -42,7 +42,6 @@ export interface CancelEvent extends BaseEvent {
 
 export interface VisionStartEvent extends BaseEvent {
   type: 'vision_start';
-  rtsp_url: string;
 }
 
 export interface VisionStopEvent extends BaseEvent {
@@ -106,7 +105,6 @@ export interface VisionResultEvent extends BaseEvent {
     gesture: string;
     confidence: number;
   }>;
-  debug_frame?: string; // Base64 JPEG with annotations
 }
 
 export type ServerEvent =
@@ -241,7 +239,7 @@ class WebSocketManager {
   /**
    * Send an event to the server.
    */
-  send(event: Partial<ChatRequestEvent> | Partial<CancelEvent> | Partial<VisionStartEvent> | Partial<VisionStopEvent>) {
+  send(event: Partial<ChatRequestEvent> | Partial<CancelEvent> | Partial<VisionStartEvent> | Partial<VisionStopEvent> | Record<string, unknown>) {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       throw new Error('WebSocket not connected');
     }
@@ -281,7 +279,7 @@ class WebSocketManager {
   /**
    * Send a vision start request.
    */
-  async sendVisionStart(rtspUrl: string, options?: {
+  async sendVisionStart(options?: {
     enable_face?: boolean;
     enable_pose?: boolean;
     enable_hands?: boolean;
@@ -289,11 +287,19 @@ class WebSocketManager {
     await this.connect();
     this.send({
       type: 'vision_start',
-      rtsp_url: rtspUrl,
       enable_face: options?.enable_face ?? true,
       enable_pose: options?.enable_pose ?? true,
       enable_hands: options?.enable_hands ?? true,
     });
+  }
+
+  /**
+   * Send a webcam frame for inference.
+   */
+  sendVisionFrame(frameBase64: string) {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.send({ type: 'vision_frame', frame: frameBase64 });
+    }
   }
 
   /**

--- a/src/components/CharacterConfigDialog.tsx
+++ b/src/components/CharacterConfigDialog.tsx
@@ -27,7 +27,6 @@ import {
   ReactFlow,
   useNodesState,
   useEdgesState,
-  addEdge,
   Controls,
   Background,
   BackgroundVariant,
@@ -46,14 +45,13 @@ import '@xyflow/react/dist/style.css';
 import { apiClient } from '../api/client';
 import type { Agent } from '../api/types';
 import type { AnimationNode, AnimationEdge, PoseTree, PoseConfig } from '../videocall/types';
+import { migrateEdgeToTransitions } from '../videocall/types';
 import PoseGraphNode from './PoseGraphNode';
 import type { PoseGraphNodeData } from './PoseGraphNode';
 import { PoseNodeEditor } from './PoseNodeEditor';
 import { EdgeEditor } from './EdgeEditor';
 
-// ─── Custom offset edge (for bidirectional pairs drawn side-by-side) ───
-
-const OFFSET_PX = 8; // perpendicular offset for each direction
+// ─── Custom edge (with self-loop support) ───
 
 const LOOP_RADIUS = 30; // radius of self-loop circle
 
@@ -70,7 +68,6 @@ const OffsetEdge: React.FC<EdgeProps> = ({
   label,
   data,
 }) => {
-  const offset = (data?.offset as number) || 0;
   const isSelfLoop = source === target;
 
   let path: string;
@@ -78,12 +75,9 @@ const OffsetEdge: React.FC<EdgeProps> = ({
   let midY: number;
 
   if (isSelfLoop) {
-    // Draw a loop above the node — always use fixed width so it's visible
-    // even when both handles resolve to the same point
     const r = LOOP_RADIUS;
     const cx = (sourceX + targetX) / 2;
     const baseY = Math.min(sourceY, targetY);
-    // Spread the start/end apart so the loop is always visible
     const halfW = Math.max(Math.abs(targetX - sourceX) / 2, r);
     const sx = cx - halfW;
     const tx = cx + halfW;
@@ -92,21 +86,9 @@ const OffsetEdge: React.FC<EdgeProps> = ({
     midX = cx;
     midY = topY + r * 0.5;
   } else {
-    // Perpendicular offset for straight line
-    const dx = targetX - sourceX;
-    const dy = targetY - sourceY;
-    const len = Math.sqrt(dx * dx + dy * dy) || 1;
-    const nx = -dy / len;
-    const ny = dx / len;
-
-    const sx = sourceX + nx * offset;
-    const sy = sourceY + ny * offset;
-    const tx = targetX + nx * offset;
-    const ty = targetY + ny * offset;
-
-    path = `M ${sx} ${sy} L ${tx} ${ty}`;
-    midX = (sx + tx) / 2;
-    midY = (sy + ty) / 2;
+    path = `M ${sourceX} ${sourceY} L ${targetX} ${targetY}`;
+    midX = (sourceX + targetX) / 2;
+    midY = (sourceY + targetY) / 2;
   }
 
   const labelStyle = data?.labelStyle as React.CSSProperties | undefined;
@@ -147,6 +129,8 @@ const OffsetEdge: React.FC<EdgeProps> = ({
 const CONDITION_COLORS: Record<string, string> = {
   random: '#2196F3',
   thinking: '#9C27B0',
+  gesture: '#FF9800',
+  mixed: '#FF9800',
   _default: '#888',
 };
 
@@ -155,19 +139,35 @@ function getEdgeVisuals(animEdge?: AnimationEdge): {
   markerEnd: { type: MarkerType; width: number; height: number; color: string };
   label: string;
 } {
-  const condType = animEdge?.condition?.type;
-  const color = (condType && CONDITION_COLORS[condType]) || CONDITION_COLORS._default;
-  const hasVideo = !!(animEdge?.video_urls?.length);
+  const transitions = animEdge?.transitions || [];
+  const hasVideo = transitions.some((t) => t.video_urls?.length);
 
   let label = '';
-  if (condType === 'random' && animEdge?.condition?.type === 'random') {
-    const c = animEdge.condition as import('../videocall/types').RandomCondition;
-    label = `Random ${(c.min_interval_ms / 1000).toFixed(0)}–${(c.max_interval_ms / 1000).toFixed(0)}s`;
-  } else if (condType === 'thinking' && animEdge?.condition?.type === 'thinking') {
-    const c = animEdge.condition as import('../videocall/types').ThinkingCondition;
-    label = `Thinking: ${c.value}`;
-  } else if (!condType) {
+  let color = CONDITION_COLORS._default;
+
+  if (transitions.length === 0) {
     label = 'No condition';
+  } else if (transitions.length === 1) {
+    const cond = transitions[0].condition;
+    color = CONDITION_COLORS[cond.type] || CONDITION_COLORS._default;
+    if (cond.type === 'random') {
+      label = `Random ${(cond.min_interval_ms / 1000).toFixed(0)}\u2013${(cond.max_interval_ms / 1000).toFixed(0)}s`;
+    } else if (cond.type === 'thinking') {
+      label = `Thinking: ${cond.value}`;
+    } else if (cond.type === 'gesture') {
+      label = `Gesture: ${cond.value}`;
+    }
+  } else {
+    // Multiple transitions — check if all same type
+    const types = new Set(transitions.map((t) => t.condition.type));
+    if (types.size === 1) {
+      const singleType = transitions[0].condition.type;
+      color = CONDITION_COLORS[singleType] || CONDITION_COLORS._default;
+      label = `${transitions.length} ${singleType} transitions`;
+    } else {
+      color = CONDITION_COLORS.mixed;
+      label = `${transitions.length} transitions`;
+    }
   }
 
   return {
@@ -179,11 +179,6 @@ function getEdgeVisuals(animEdge?: AnimationEdge): {
     markerEnd: { type: MarkerType.ArrowClosed, width: 20, height: 20, color },
     label,
   };
-}
-
-/** Build a set of "src->tgt" keys for quick reverse-edge lookup. */
-function buildEdgePairSet(edges: { from_node_id: string; to_node_id: string }[]): Set<string> {
-  return new Set(edges.map((e) => `${e.from_node_id}->${e.to_node_id}`));
 }
 
 /** Pick the best source/target handle IDs based on relative node positions. */
@@ -236,16 +231,13 @@ function poseTreeToReactFlow(
     posMap.set(n.id, n.position || { x: 0, y: 0 });
   }
 
-  const pairSet = buildEdgePairSet(poseTree.edges);
-
   const edges: RFEdge[] = poseTree.edges.map((e) => {
     const isSelfLoop = e.from_node_id === e.to_node_id;
     const srcPos = posMap.get(e.from_node_id) || { x: 0, y: 0 };
     const tgtPos = posMap.get(e.to_node_id) || { x: 0, y: 0 };
     const handles = getBestHandles(srcPos, tgtPos, isSelfLoop);
     const visuals = getEdgeVisuals(e);
-    const hasReverse = !isSelfLoop && pairSet.has(`${e.to_node_id}->${e.from_node_id}`);
-    const offset = hasReverse ? OFFSET_PX : 0;
+
     return {
       id: e.id,
       source: e.from_node_id,
@@ -257,7 +249,6 @@ function poseTreeToReactFlow(
       markerEnd: visuals.markerEnd,
       label: visuals.label,
       data: {
-        offset,
         labelStyle: { fill: visuals.style.stroke as string },
         labelBgStyle: { fill: '#fff', fillOpacity: 0.85 },
       },
@@ -292,9 +283,7 @@ function reactFlowToPoseTree(
       id: rfEdge.id,
       from_node_id: rfEdge.source,
       to_node_id: rfEdge.target,
-      video_urls: existing?.video_urls,
-      condition: existing?.condition,
-      playback_rate: existing?.playback_rate,
+      transitions: existing?.transitions || [],
     };
   });
 
@@ -389,19 +378,23 @@ export const CharacterConfigDialog: React.FC<CharacterConfigDialogProps> = ({
           if (!n.position) n.position = { x: 0, y: 0 };
           nodesMap.set(n.id, n);
         }
+        // Migrate edges to transitions[] format and merge into one edge per directed pair
+        const pairEdgeMap = new Map<string, AnimationEdge>();
+        for (const rawEdge of poseTree.edges) {
+          const migrated = migrateEdgeToTransitions(rawEdge);
+          const pairKey = `${migrated.from_node_id}->${migrated.to_node_id}`;
+          const deterministicId = `edge-${migrated.from_node_id}-${migrated.to_node_id}`;
+          const existing = pairEdgeMap.get(pairKey);
+          if (existing) {
+            // Merge transitions from legacy parallel edges into one
+            existing.transitions.push(...migrated.transitions);
+          } else {
+            migrated.id = deterministicId;
+            pairEdgeMap.set(pairKey, migrated);
+          }
+        }
+        poseTree.edges = [...pairEdgeMap.values()];
         for (const e of poseTree.edges) {
-          // Migrate legacy video_url (string) → video_urls (array)
-          const raw = e as AnimationEdge & { video_url?: string };
-          if (raw.video_url && !raw.video_urls?.length) {
-            e.video_urls = [raw.video_url];
-            delete raw.video_url;
-          }
-          // Migrate legacy thinking trigger → value
-          if (e.condition?.type === 'thinking' && !('value' in e.condition)) {
-            const legacy = e.condition as any;
-            e.condition = { type: 'thinking', value: legacy.trigger === 'start' };
-            delete legacy.trigger;
-          }
           edgesMap.set(e.id, e);
         }
 
@@ -518,55 +511,47 @@ export const CharacterConfigDialog: React.FC<CharacterConfigDialogProps> = ({
   // ─── Edge connection ───
   const onConnect = useCallback((connection: Connection) => {
     if (!connection.source || !connection.target) return;
+    const edgeId = `edge-${connection.source}-${connection.target}`;
     const isSelfLoop = connection.source === connection.target;
-    const edgeId = isSelfLoop
-      ? `edge-${connection.source}-self`
-      : `edge-${connection.source}-${connection.target}`;
 
-    // Create animation edge data
+    // If an edge already exists for this directed pair, open editor instead
+    if (animationEdgesRef.current.has(edgeId)) {
+      setEditingEdgeId(edgeId);
+      setEdgeEditorOpen(true);
+      return;
+    }
+
+    // Create animation edge with default transition
     const animEdge: AnimationEdge = {
       id: edgeId,
       from_node_id: connection.source,
       to_node_id: connection.target,
-      condition: { type: 'random', min_interval_ms: 5000, max_interval_ms: 15000 },
+      transitions: [{ condition: { type: 'random', min_interval_ms: 5000, max_interval_ms: 15000 } }],
     };
     animationEdgesRef.current.set(edgeId, animEdge);
 
     const visuals = getEdgeVisuals(animEdge);
-    setRfEdges((eds) => {
-      // Check if reverse edge exists → both need offset (skip for self-loops)
-      const hasReverse = !isSelfLoop && eds.some(
-        (e) => e.source === connection.target && e.target === connection.source,
-      );
-      let updated = eds;
-      if (hasReverse) {
-        // Apply offset to the existing reverse edge too
-        updated = eds.map((e) =>
-          e.source === connection.target && e.target === connection.source
-            ? { ...e, data: { ...e.data, offset: OFFSET_PX } }
-            : e,
-        );
-      }
 
-      // Self-loop: override handles so the loop arcs above the node
-      const conn = isSelfLoop
-        ? { ...connection, sourceHandle: 's-top', targetHandle: 't-top' }
-        : connection;
+    // Self-loop: override handles so the loop arcs above the node
+    const handles = isSelfLoop
+      ? { sourceHandle: 's-top', targetHandle: 't-top' }
+      : { sourceHandle: connection.sourceHandle, targetHandle: connection.targetHandle };
 
-      return addEdge({
-        ...conn,
-        id: edgeId,
-        type: 'offsetEdge',
-        style: visuals.style,
-        markerEnd: visuals.markerEnd,
-        label: visuals.label,
-        data: {
-          offset: hasReverse ? OFFSET_PX : 0,
-          labelStyle: { fill: visuals.style.stroke as string },
-          labelBgStyle: { fill: '#fff', fillOpacity: 0.85 },
-        },
-      }, updated);
-    });
+    const newEdge: RFEdge = {
+      id: edgeId,
+      source: connection.source!,
+      target: connection.target!,
+      ...handles,
+      type: 'offsetEdge',
+      style: visuals.style,
+      markerEnd: visuals.markerEnd,
+      label: visuals.label,
+      data: {
+        labelStyle: { fill: visuals.style.stroke as string },
+        labelBgStyle: { fill: '#fff', fillOpacity: 0.85 },
+      },
+    };
+    setRfEdges((eds) => [...eds, newEdge]);
     triggerAutoSave();
   }, [setRfEdges, triggerAutoSave]);
 
@@ -752,19 +737,7 @@ export const CharacterConfigDialog: React.FC<CharacterConfigDialogProps> = ({
   const handleEdgeEditorDelete = () => {
     if (!editingEdgeId) return;
     animationEdgesRef.current.delete(editingEdgeId);
-    setRfEdges((eds) => {
-      const deleted = eds.find((e) => e.id === editingEdgeId);
-      let remaining = eds.filter((e) => e.id !== editingEdgeId);
-      // If the deleted edge had a reverse partner, remove the partner's offset
-      if (deleted) {
-        remaining = remaining.map((e) =>
-          e.source === deleted.target && e.target === deleted.source
-            ? { ...e, data: { ...e.data, offset: 0 } }
-            : e,
-        );
-      }
-      return remaining;
-    });
+    setRfEdges((eds) => eds.filter((e) => e.id !== editingEdgeId));
     setEdgeEditorOpen(false);
     setEditingEdgeId(null);
     triggerAutoSave();

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -23,6 +23,8 @@ import {
   Stop as StopIcon,
   Mic as MicIcon,
   MicOff as MicOffIcon,
+  Videocam as VideocamIcon,
+  VideocamOff as VideocamOffIcon,
 } from '@mui/icons-material';
 import CircularProgress from '@mui/material/CircularProgress';
 import { AnimatePresence } from 'framer-motion';
@@ -32,6 +34,7 @@ import { wsManager, StreamChunkEvent, DoneEvent, ErrorEvent, BaseEvent } from '.
 import { storage } from '../utils/storage';
 import { useTTS } from '../hooks/useTTS';
 import { useASR } from '../hooks/useASR';
+import { useVisionStore } from '../store/visionStore';
 import type { AmplitudeState } from '../videocall/CharacterRenderer';
 import type { PoseTree } from '../videocall/types';
 import { MessageBubble } from './MessageBubble';
@@ -97,6 +100,18 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     devices: asrDevices, loadDevices: loadAsrDevices, selectedDeviceId: asrDeviceId, selectDevice: selectAsrDevice,
   } = useASR();
   const [micMenuAnchor, setMicMenuAnchor] = useState<HTMLElement | null>(null);
+
+  // Vision (camera toggle)
+  const {
+    isActive: cameraActive,
+    webcams: cameraWebcams,
+    selectedWebcam: cameraSelectedWebcam,
+    loadWebcams: loadCameraWebcams,
+    startVision,
+    stopVision,
+    setSelectedWebcam: setCameraSelectedWebcam,
+  } = useVisionStore();
+  const [cameraMenuAnchor, setCameraMenuAnchor] = useState<HTMLElement | null>(null);
 
   // Ref to track streaming state without stale closures
   const isStreamingRef = useRef(false);
@@ -755,6 +770,23 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     });
   };
 
+  const handleCameraToggle = async () => {
+    if (cameraActive) {
+      stopVision();
+    } else {
+      if (cameraWebcams.length === 0) await loadCameraWebcams();
+      startVision();
+    }
+  };
+
+  const handleCameraContext = (e: React.MouseEvent<HTMLElement>) => {
+    e.preventDefault();
+    const anchor = e.currentTarget;
+    loadCameraWebcams().then(() => {
+      setCameraMenuAnchor(anchor);
+    });
+  };
+
   const toggleThinking = (index: number) => {
     setExpandedThinking(prev => {
       const newSet = new Set(prev);
@@ -999,6 +1031,46 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
             ))}
             {asrDevices.length === 0 && (
               <MenuItem disabled>No microphones found</MenuItem>
+            )}
+          </Menu>
+
+          <Tooltip title={cameraActive ? 'Stop camera (right-click: select webcam)' : 'Start camera (right-click: select webcam)'}>
+            <IconButton
+              onClick={handleCameraToggle}
+              onContextMenu={handleCameraContext}
+              disabled={isStreaming}
+              sx={{
+                color: cameraActive ? 'success.main' : 'inherit',
+                animation: cameraActive ? 'pulse 1.5s infinite' : 'none',
+              }}
+            >
+              {cameraActive ? <VideocamIcon /> : <VideocamOffIcon />}
+            </IconButton>
+          </Tooltip>
+          <Menu
+            anchorEl={cameraMenuAnchor}
+            open={Boolean(cameraMenuAnchor)}
+            onClose={() => setCameraMenuAnchor(null)}
+          >
+            {cameraWebcams.map((cam) => (
+              <MenuItem
+                key={cam}
+                onClick={() => {
+                  setCameraSelectedWebcam(cam);
+                  setCameraMenuAnchor(null);
+                }}
+                selected={cam === cameraSelectedWebcam}
+              >
+                {cam === cameraSelectedWebcam && (
+                  <ListItemIcon><CheckIcon fontSize="small" /></ListItemIcon>
+                )}
+                <ListItemText inset={cam !== cameraSelectedWebcam}>
+                  {cam}
+                </ListItemText>
+              </MenuItem>
+            ))}
+            {cameraWebcams.length === 0 && (
+              <MenuItem disabled>No webcams found</MenuItem>
             )}
           </Menu>
 

--- a/src/components/EdgeEditor.tsx
+++ b/src/components/EdgeEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import {
   Box,
   Dialog,
@@ -18,14 +18,13 @@ import {
   Slider,
 } from '@mui/material';
 import {
-  CloudUpload as CloudUploadIcon,
   Close as CloseIcon,
   Delete as DeleteIcon,
   Add as AddIcon,
 } from '@mui/icons-material';
 import { apiClient } from '../api/client';
 import { config } from '../config';
-import type { AnimationEdge, TransitionCondition } from '../videocall/types';
+import type { AnimationEdge, EdgeTransition, TransitionCondition } from '../videocall/types';
 
 export interface EdgeEditorProps {
   open: boolean;
@@ -44,6 +43,45 @@ interface VideoEntry {
   previewSrc: string;  // Display URL (blob: for local, resolved server URL for existing)
 }
 
+interface TransitionState {
+  conditionType: string;
+  minInterval: number;
+  maxInterval: number;
+  thinkingValue: boolean;
+  gestureValue: string;
+  videos: VideoEntry[];
+  playbackRate: number;
+}
+
+const GESTURE_OPTIONS = ['wave', 'thumbs_up', 'peace_sign', 'pointing', 'open_palm'];
+
+function transitionToState(t: EdgeTransition): TransitionState {
+  return {
+    conditionType: t.condition.type,
+    minInterval: t.condition.type === 'random' ? t.condition.min_interval_ms / 1000 : 5,
+    maxInterval: t.condition.type === 'random' ? t.condition.max_interval_ms / 1000 : 15,
+    thinkingValue: t.condition.type === 'thinking' ? t.condition.value : true,
+    gestureValue: t.condition.type === 'gesture' ? t.condition.value : 'wave',
+    videos: (t.video_urls || []).map((url) => ({
+      url,
+      previewSrc: url.startsWith('http') ? url : `${config.apiBaseUrl}${url}`,
+    })),
+    playbackRate: t.playback_rate ?? 1.0,
+  };
+}
+
+function defaultTransitionState(): TransitionState {
+  return {
+    conditionType: 'random',
+    minInterval: 5,
+    maxInterval: 15,
+    thinkingValue: true,
+    gestureValue: 'wave',
+    videos: [],
+    playbackRate: 1.0,
+  };
+}
+
 export const EdgeEditor: React.FC<EdgeEditorProps> = ({
   open,
   agentId,
@@ -56,56 +94,42 @@ export const EdgeEditor: React.FC<EdgeEditorProps> = ({
 }) => {
   const [error, setError] = useState('');
   const [uploading, setUploading] = useState(false);
-  const [videos, setVideos] = useState<VideoEntry[]>([]);
-  const [conditionType, setConditionType] = useState<string>(edge.condition?.type || 'random');
-  const [minInterval, setMinInterval] = useState<number>(
-    edge.condition?.type === 'random' ? edge.condition.min_interval_ms / 1000 : 5
-  );
-  const [maxInterval, setMaxInterval] = useState<number>(
-    edge.condition?.type === 'random' ? edge.condition.max_interval_ms / 1000 : 15
-  );
-  const [thinkingValue, setThinkingValue] = useState<boolean>(
-    edge.condition?.type === 'thinking' ? edge.condition.value : true
-  );
-  const [playbackRate, setPlaybackRate] = useState<number>(edge.playback_rate ?? 1.0);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const resolveUrl = (url: string) =>
-    url.startsWith('http') ? url : `${config.apiBaseUrl}${url}`;
+  const [transitions, setTransitions] = useState<TransitionState[]>([]);
+  const fileInputRefs = useRef<Map<number, HTMLInputElement>>(new Map());
+  // Track which transition index the file input belongs to
+  const activeFileInputIdx = useRef<number>(0);
 
   // Reset state when edge changes
   useEffect(() => {
     if (!open) return;
-
-    const entries: VideoEntry[] = (edge.video_urls || []).map((url) => ({
-      url,
-      previewSrc: resolveUrl(url),
-    }));
-    setVideos(entries);
-
-    setConditionType(edge.condition?.type || 'random');
-    setMinInterval(edge.condition?.type === 'random' ? edge.condition.min_interval_ms / 1000 : 5);
-    setMaxInterval(edge.condition?.type === 'random' ? edge.condition.max_interval_ms / 1000 : 15);
-    setThinkingValue(edge.condition?.type === 'thinking' ? edge.condition.value : true);
-    setPlaybackRate(edge.playback_rate ?? 1.0);
+    setTransitions(
+      edge.transitions.length > 0
+        ? edge.transitions.map(transitionToState)
+        : [defaultTransitionState()],
+    );
     setError('');
   }, [open, edge]);
 
-  // Clean up blob URLs on unmount or when videos change
+  // Clean up blob URLs on unmount
   useEffect(() => {
     return () => {
-      for (const v of videos) {
-        if (v.previewSrc.startsWith('blob:')) {
-          URL.revokeObjectURL(v.previewSrc);
+      for (const t of transitions) {
+        for (const v of t.videos) {
+          if (v.previewSrc.startsWith('blob:')) URL.revokeObjectURL(v.previewSrc);
         }
       }
     };
-  }, [videos]);
+  }, [transitions]);
+
+  const updateTransition = useCallback((idx: number, partial: Partial<TransitionState>) => {
+    setTransitions((prev) => prev.map((t, i) => (i === idx ? { ...t, ...partial } : t)));
+  }, []);
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
     e.target.value = '';
+    const tIdx = activeFileInputIdx.current;
 
     if (!file.type.startsWith('video/')) {
       setError('File must be a video (mp4 or webm)');
@@ -113,18 +137,31 @@ export const EdgeEditor: React.FC<EdgeEditorProps> = ({
     }
 
     const previewSrc = URL.createObjectURL(file);
-    setVideos((prev) => [...prev, { url: '', pendingFile: file, previewSrc }]);
+    setTransitions((prev) =>
+      prev.map((t, i) =>
+        i === tIdx ? { ...t, videos: [...t.videos, { url: '', pendingFile: file, previewSrc }] } : t,
+      ),
+    );
     setError('');
   };
 
-  const handleRemoveVideo = (index: number) => {
-    setVideos((prev) => {
-      const entry = prev[index];
-      if (entry.previewSrc.startsWith('blob:')) {
-        URL.revokeObjectURL(entry.previewSrc);
-      }
-      return prev.filter((_, i) => i !== index);
-    });
+  const handleRemoveVideo = (tIdx: number, vIdx: number) => {
+    setTransitions((prev) =>
+      prev.map((t, i) => {
+        if (i !== tIdx) return t;
+        const entry = t.videos[vIdx];
+        if (entry.previewSrc.startsWith('blob:')) URL.revokeObjectURL(entry.previewSrc);
+        return { ...t, videos: t.videos.filter((_, vi) => vi !== vIdx) };
+      }),
+    );
+  };
+
+  const handleDeleteTransition = (tIdx: number) => {
+    setTransitions((prev) => prev.filter((_, i) => i !== tIdx));
+  };
+
+  const handleAddTransition = () => {
+    setTransitions((prev) => [...prev, defaultTransitionState()]);
   };
 
   const handleSave = async () => {
@@ -132,41 +169,46 @@ export const EdgeEditor: React.FC<EdgeEditorProps> = ({
     setUploading(true);
 
     try {
-      // Upload any pending files, assign indexed edge IDs
-      const finalUrls: string[] = [];
-      for (let i = 0; i < videos.length; i++) {
-        const entry = videos[i];
-        if (entry.pendingFile) {
-          const storageId = `${edge.id}_${i}`;
-          const result = await apiClient.uploadTransitionVideo(agentId, storageId, entry.pendingFile);
-          finalUrls.push(result.video_url);
-        } else if (entry.url) {
-          finalUrls.push(entry.url);
-        }
-      }
+      const finalTransitions: EdgeTransition[] = [];
 
-      // Build condition
-      let condition: TransitionCondition | undefined;
-      if (conditionType === 'random') {
-        const minMs = Math.max(100, Math.round(minInterval * 1000));
-        const maxMs = Math.max(minMs + 100, Math.round(maxInterval * 1000));
-        condition = {
-          type: 'random',
-          min_interval_ms: minMs,
-          max_interval_ms: maxMs,
-        };
-      } else if (conditionType === 'thinking') {
-        condition = {
-          type: 'thinking',
-          value: thinkingValue,
-        };
+      for (let ti = 0; ti < transitions.length; ti++) {
+        const ts = transitions[ti];
+
+        // Upload pending video files
+        const finalUrls: string[] = [];
+        for (let vi = 0; vi < ts.videos.length; vi++) {
+          const entry = ts.videos[vi];
+          if (entry.pendingFile) {
+            const storageId = `${edge.id}_t${ti}_${vi}`;
+            const result = await apiClient.uploadTransitionVideo(agentId, storageId, entry.pendingFile);
+            finalUrls.push(result.video_url);
+          } else if (entry.url) {
+            finalUrls.push(entry.url);
+          }
+        }
+
+        // Build condition
+        let condition: TransitionCondition;
+        if (ts.conditionType === 'thinking') {
+          condition = { type: 'thinking', value: ts.thinkingValue };
+        } else if (ts.conditionType === 'gesture') {
+          condition = { type: 'gesture', value: ts.gestureValue };
+        } else {
+          const minMs = Math.max(100, Math.round(ts.minInterval * 1000));
+          const maxMs = Math.max(minMs + 100, Math.round(ts.maxInterval * 1000));
+          condition = { type: 'random', min_interval_ms: minMs, max_interval_ms: maxMs };
+        }
+
+        finalTransitions.push({
+          condition,
+          video_urls: finalUrls.length > 0 ? finalUrls : undefined,
+          playback_rate: ts.playbackRate !== 1.0 ? ts.playbackRate : undefined,
+        });
       }
 
       onSave({
         ...edge,
-        video_urls: finalUrls.length > 0 ? finalUrls : undefined,
-        condition,
-        playback_rate: playbackRate !== 1.0 ? playbackRate : undefined,
+        transitions: finalTransitions,
       });
     } catch (err: any) {
       setError(err.response?.data?.detail || err.message || 'Failed to save edge');
@@ -193,127 +235,182 @@ export const EdgeEditor: React.FC<EdgeEditorProps> = ({
           </Alert>
         )}
 
-        {/* Video list */}
-        <Typography variant="subtitle2" sx={{ mb: 1 }}>Transition Videos</Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Upload one or more videos (mp4/webm). A random one plays each time the transition fires. No videos = instant switch.
-        </Typography>
-
-        {videos.map((entry, index) => (
+        {transitions.map((ts, tIdx) => (
           <Box
-            key={index}
+            key={tIdx}
             sx={{
-              mb: 1.5,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 1,
-              p: 1,
+              mb: 2,
+              p: 2,
               borderRadius: 1,
               border: '1px solid',
               borderColor: 'divider',
             }}
           >
-            <video
-              src={entry.previewSrc}
-              controls
-              style={{ width: 200, maxHeight: 120, borderRadius: 4, background: '#000', flexShrink: 0 }}
-            />
-            <Box sx={{ flex: 1, minWidth: 0 }}>
-              <Typography variant="caption" color="text.secondary" noWrap>
-                {entry.pendingFile ? entry.pendingFile.name : `Video ${index + 1}`}
-              </Typography>
-              {entry.pendingFile && (
-                <Typography variant="caption" display="block" color="warning.main">
-                  Not yet uploaded
-                </Typography>
-              )}
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1.5 }}>
+              <Typography variant="subtitle2">Transition {tIdx + 1}</Typography>
+              <IconButton
+                size="small"
+                color="error"
+                onClick={() => handleDeleteTransition(tIdx)}
+                disabled={transitions.length <= 1}
+                title={transitions.length <= 1 ? 'At least one transition required' : 'Delete transition'}
+              >
+                <DeleteIcon fontSize="small" />
+              </IconButton>
             </Box>
-            <IconButton size="small" onClick={() => handleRemoveVideo(index)} color="error">
-              <DeleteIcon fontSize="small" />
-            </IconButton>
+
+            {/* Condition */}
+            <FormControl size="small" sx={{ mb: 1.5, minWidth: 200 }}>
+              <InputLabel>Condition</InputLabel>
+              <Select
+                value={ts.conditionType}
+                label="Condition"
+                onChange={(e) => updateTransition(tIdx, { conditionType: e.target.value })}
+              >
+                <MenuItem value="random">Random Timer</MenuItem>
+                <MenuItem value="thinking">Thinking</MenuItem>
+                <MenuItem value="gesture">Gesture</MenuItem>
+              </Select>
+            </FormControl>
+
+            {ts.conditionType === 'random' && (
+              <Box sx={{ display: 'flex', gap: 2, mb: 1.5 }}>
+                <TextField
+                  label="Min (s)"
+                  type="number"
+                  size="small"
+                  value={ts.minInterval}
+                  onChange={(e) => updateTransition(tIdx, { minInterval: Math.max(0.1, Number(e.target.value)) })}
+                  inputProps={{ min: 0.1, step: 0.5 }}
+                  sx={{ flex: 1 }}
+                />
+                <TextField
+                  label="Max (s)"
+                  type="number"
+                  size="small"
+                  value={ts.maxInterval}
+                  onChange={(e) => updateTransition(tIdx, { maxInterval: Math.max(0.1, Number(e.target.value)) })}
+                  inputProps={{ min: 0.1, step: 0.5 }}
+                  sx={{ flex: 1 }}
+                />
+              </Box>
+            )}
+
+            {ts.conditionType === 'thinking' && (
+              <FormControl size="small" sx={{ mb: 1.5, minWidth: 200 }}>
+                <InputLabel>When</InputLabel>
+                <Select
+                  value={ts.thinkingValue ? 'true' : 'false'}
+                  label="When"
+                  onChange={(e) => updateTransition(tIdx, { thinkingValue: e.target.value === 'true' })}
+                >
+                  <MenuItem value="true">Thinking starts</MenuItem>
+                  <MenuItem value="false">Thinking ends</MenuItem>
+                </Select>
+              </FormControl>
+            )}
+
+            {ts.conditionType === 'gesture' && (
+              <FormControl size="small" sx={{ mb: 1.5, minWidth: 200 }}>
+                <InputLabel>Gesture</InputLabel>
+                <Select
+                  value={ts.gestureValue}
+                  label="Gesture"
+                  onChange={(e) => updateTransition(tIdx, { gestureValue: e.target.value })}
+                >
+                  {GESTURE_OPTIONS.map((g) => (
+                    <MenuItem key={g} value={g}>{g.replace('_', ' ')}</MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+
+            {/* Videos */}
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              Videos (random pick per fire, none = instant switch)
+            </Typography>
+
+            {ts.videos.map((entry, vIdx) => (
+              <Box
+                key={vIdx}
+                sx={{
+                  mb: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1,
+                  p: 0.5,
+                  borderRadius: 1,
+                  border: '1px solid',
+                  borderColor: 'divider',
+                }}
+              >
+                <video
+                  src={entry.previewSrc}
+                  controls
+                  style={{ width: 160, maxHeight: 90, borderRadius: 4, background: '#000', flexShrink: 0 }}
+                />
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography variant="caption" color="text.secondary" noWrap>
+                    {entry.pendingFile ? entry.pendingFile.name : `Video ${vIdx + 1}`}
+                  </Typography>
+                  {entry.pendingFile && (
+                    <Typography variant="caption" display="block" color="warning.main">
+                      Pending upload
+                    </Typography>
+                  )}
+                </Box>
+                <IconButton size="small" onClick={() => handleRemoveVideo(tIdx, vIdx)} color="error">
+                  <DeleteIcon fontSize="small" />
+                </IconButton>
+              </Box>
+            ))}
+
+            <input
+              ref={(el) => { if (el) fileInputRefs.current.set(tIdx, el); }}
+              type="file"
+              accept="video/mp4,video/webm"
+              style={{ display: 'none' }}
+              onChange={handleFileSelect}
+            />
+            <Button
+              variant="text"
+              size="small"
+              startIcon={<AddIcon />}
+              onClick={() => {
+                activeFileInputIdx.current = tIdx;
+                fileInputRefs.current.get(tIdx)?.click();
+              }}
+              sx={{ mb: 0.5 }}
+            >
+              Add Video
+            </Button>
+
+            {/* Playback rate */}
+            <Box sx={{ mt: 1 }}>
+              <Typography variant="caption" color="text.secondary">
+                Playback rate: {ts.playbackRate.toFixed(2)}x
+              </Typography>
+              <Slider
+                value={ts.playbackRate}
+                onChange={(_, v) => updateTransition(tIdx, { playbackRate: v as number })}
+                min={0.25}
+                max={4}
+                step={0.25}
+                size="small"
+              />
+            </Box>
           </Box>
         ))}
 
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="video/mp4,video/webm"
-          style={{ display: 'none' }}
-          onChange={handleFileSelect}
-        />
         <Button
           variant="outlined"
           size="small"
           startIcon={<AddIcon />}
-          onClick={() => fileInputRef.current?.click()}
-          sx={{ mb: 3 }}
+          onClick={handleAddTransition}
+          fullWidth
         >
-          Add Video
+          Add Transition
         </Button>
-
-        {/* Condition */}
-        <Typography variant="subtitle2" sx={{ mb: 1 }}>Trigger Condition</Typography>
-        <FormControl size="small" sx={{ mb: 2, minWidth: 200 }}>
-          <InputLabel>Type</InputLabel>
-          <Select
-            value={conditionType}
-            label="Type"
-            onChange={(e) => setConditionType(e.target.value)}
-          >
-            <MenuItem value="random">Random Timer</MenuItem>
-            <MenuItem value="thinking">Thinking</MenuItem>
-          </Select>
-        </FormControl>
-
-        {conditionType === 'thinking' && (
-          <FormControl size="small" sx={{ mb: 2, minWidth: 200 }}>
-            <InputLabel>When</InputLabel>
-            <Select
-              value={thinkingValue ? 'true' : 'false'}
-              label="When"
-              onChange={(e) => setThinkingValue(e.target.value === 'true')}
-            >
-              <MenuItem value="true">True</MenuItem>
-              <MenuItem value="false">False</MenuItem>
-            </Select>
-          </FormControl>
-        )}
-
-        {conditionType === 'random' && (
-          <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
-            <TextField
-              label="Min interval (seconds)"
-              type="number"
-              size="small"
-              value={minInterval}
-              onChange={(e) => setMinInterval(Math.max(0.1, Number(e.target.value)))}
-              inputProps={{ min: 0.1, step: 0.5 }}
-              sx={{ flex: 1 }}
-            />
-            <TextField
-              label="Max interval (seconds)"
-              type="number"
-              size="small"
-              value={maxInterval}
-              onChange={(e) => setMaxInterval(Math.max(0.1, Number(e.target.value)))}
-              inputProps={{ min: 0.1, step: 0.5 }}
-              sx={{ flex: 1 }}
-            />
-          </Box>
-        )}
-
-        {/* Playback rate */}
-        <Typography variant="subtitle2" sx={{ mb: 1 }}>Video Playback Rate</Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>{playbackRate.toFixed(2)}x</Typography>
-        <Slider
-          value={playbackRate}
-          onChange={(_, v) => setPlaybackRate(v as number)}
-          min={0.25}
-          max={4}
-          step={0.25}
-          size="small"
-          sx={{ mb: 2 }}
-        />
       </DialogContent>
 
       <DialogActions>

--- a/src/components/FacesWindow.tsx
+++ b/src/components/FacesWindow.tsx
@@ -1,0 +1,786 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  Paper,
+  Grid,
+  Card,
+  CardContent,
+  CardActions,
+  Avatar,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Alert,
+  Chip,
+  Tooltip,
+  Divider,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  Select,
+  MenuItem,
+  Switch,
+} from '@mui/material';
+import {
+  Add as AddIcon,
+  Delete as DeleteIcon,
+  PhotoCamera as PhotoCameraIcon,
+  Videocam as VideocamIcon,
+  VideocamOff as VideocamOffIcon,
+  Person as PersonIcon,
+  Refresh as RefreshIcon,
+  CameraAlt as CameraAltIcon,
+  Close as CloseIcon,
+} from '@mui/icons-material';
+import { motion, AnimatePresence } from 'framer-motion';
+import { apiClient } from '../api/client';
+import { useVisionStore } from '../store/visionStore';
+import type { FaceIdentity, FaceIdentityDetail } from '../api/types';
+
+const MotionCard = motion(Card);
+
+interface CapturedPhoto {
+  file: File;
+  preview: string;
+}
+
+export const FacesWindow: React.FC = () => {
+  const [faces, setFaces] = useState<FaceIdentity[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+
+  // Create dialog
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [capturedPhotos, setCapturedPhotos] = useState<CapturedPhoto[]>([]);
+  const [scanning, setScanning] = useState(false);
+  const [creating, setCreating] = useState(false);
+
+  // Webcam
+  const [webcamStream, setWebcamStream] = useState<MediaStream | null>(null);
+  const webcamVideoRef = useRef<HTMLVideoElement>(null);
+  const webcamCanvasRef = useRef<HTMLCanvasElement>(null);
+
+  // Detail dialog
+  const [detailDialogOpen, setDetailDialogOpen] = useState(false);
+  const [selectedFace, setSelectedFace] = useState<FaceIdentityDetail | null>(null);
+  const [detailScanning, setDetailScanning] = useState(false);
+
+  // Delete dialog
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [faceToDelete, setFaceToDelete] = useState<FaceIdentity | null>(null);
+
+  // Vision
+  const {
+    isActive: visionActive,
+    latestResult,
+    webcams,
+    selectedWebcam,
+    setSelectedWebcam,
+    enableFace,
+    setEnableFace,
+    enablePose,
+    setEnablePose,
+    enableHands,
+    setEnableHands,
+    error: visionError,
+    loadWebcams,
+    startVision,
+    stopVision,
+  } = useVisionStore();
+
+  const loadFaces = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await apiClient.listFaces();
+      setFaces(data);
+    } catch (err: any) {
+      setError('Failed to load faces');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadFaces();
+    loadWebcams();
+  }, [loadFaces, loadWebcams]);
+
+  useEffect(() => {
+    if (successMessage) {
+      const timer = setTimeout(() => setSuccessMessage(''), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [successMessage]);
+
+  const startWebcam = useCallback(async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480 } });
+      setWebcamStream(stream);
+    } catch (err) {
+      setError('Failed to access webcam. Check permissions.');
+    }
+  }, []);
+
+  const stopWebcam = useCallback(() => {
+    if (webcamStream) {
+      webcamStream.getTracks().forEach((t) => t.stop());
+      setWebcamStream(null);
+    }
+  }, [webcamStream]);
+
+  // Attach stream to video element
+  useEffect(() => {
+    if (webcamVideoRef.current && webcamStream) {
+      webcamVideoRef.current.srcObject = webcamStream;
+    }
+  }, [webcamStream, scanning, detailScanning]);
+
+  const captureFrame = useCallback((): CapturedPhoto | null => {
+    const video = webcamVideoRef.current;
+    const canvas = webcamCanvasRef.current;
+    if (!video || !canvas || video.readyState < 2) return null;
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return null;
+    ctx.drawImage(video, 0, 0);
+    const dataUrl = canvas.toDataURL('image/jpeg', 0.9);
+    const arr = dataUrl.split(',');
+    const mime = arr[0].match(/:(.*?);/)?.[1] || 'image/jpeg';
+    const bstr = atob(arr[1]);
+    const u8arr = new Uint8Array(bstr.length);
+    for (let i = 0; i < bstr.length; i++) u8arr[i] = bstr.charCodeAt(i);
+    const file = new File([u8arr], `capture_${Date.now()}.jpg`, { type: mime });
+    return { file, preview: dataUrl };
+  }, []);
+
+  // Create dialog: start/stop scanning
+  const handleStartScan = useCallback(() => {
+    setScanning(true);
+    startWebcam();
+  }, [startWebcam]);
+
+  const handleStopScan = useCallback(() => {
+    setScanning(false);
+    stopWebcam();
+  }, [stopWebcam]);
+
+  const handleCapture = useCallback(() => {
+    const photo = captureFrame();
+    if (photo) {
+      setCapturedPhotos((prev) => [...prev, photo]);
+    }
+  }, [captureFrame]);
+
+  const handleRemoveCapture = useCallback((index: number) => {
+    setCapturedPhotos((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleCloseCreate = useCallback(() => {
+    setCreateDialogOpen(false);
+    setScanning(false);
+    stopWebcam();
+    setNewName('');
+    setCapturedPhotos([]);
+  }, [stopWebcam]);
+
+  const handleCreate = async () => {
+    if (!newName.trim() || capturedPhotos.length === 0) return;
+    setCreating(true);
+    try {
+      // Create face with first photo
+      const face = await apiClient.createFace(newName.trim(), capturedPhotos[0].file);
+      // Add remaining photos
+      for (let i = 1; i < capturedPhotos.length; i++) {
+        await apiClient.addFacePhoto(face.id, capturedPhotos[i].file);
+      }
+      setSuccessMessage(`Face "${newName}" registered with ${capturedPhotos.length} photo(s)`);
+      handleCloseCreate();
+      loadFaces();
+    } catch (err: any) {
+      const detail = err.response?.data?.detail || err.message;
+      setError(`Failed to register face: ${detail}`);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  // Detail dialog
+  const handleOpenDetail = async (face: FaceIdentity) => {
+    try {
+      const detail = await apiClient.getFace(face.id);
+      setSelectedFace(detail);
+      setDetailDialogOpen(true);
+    } catch (err: any) {
+      setError('Failed to load face details');
+    }
+  };
+
+  const handleDetailStartScan = useCallback(() => {
+    setDetailScanning(true);
+    startWebcam();
+  }, [startWebcam]);
+
+  const handleDetailStopScan = useCallback(() => {
+    setDetailScanning(false);
+    stopWebcam();
+  }, [stopWebcam]);
+
+  const handleDetailCapture = useCallback(async () => {
+    const photo = captureFrame();
+    if (!photo || !selectedFace) return;
+    try {
+      await apiClient.addFacePhoto(selectedFace.id, photo.file);
+      const updated = await apiClient.getFace(selectedFace.id);
+      setSelectedFace(updated);
+      loadFaces();
+      setSuccessMessage('Photo captured and added');
+    } catch (err: any) {
+      const detail = err.response?.data?.detail || err.message;
+      setError(`Failed to add photo: ${detail}`);
+    }
+  }, [captureFrame, selectedFace, loadFaces]);
+
+  const handleCloseDetail = useCallback(() => {
+    setDetailDialogOpen(false);
+    setDetailScanning(false);
+    stopWebcam();
+  }, [stopWebcam]);
+
+  const handleDeletePhoto = async (photoId: number) => {
+    if (!selectedFace) return;
+    try {
+      await apiClient.deleteFacePhoto(selectedFace.id, photoId);
+      const updated = await apiClient.getFace(selectedFace.id);
+      setSelectedFace(updated);
+      loadFaces();
+    } catch (err: any) {
+      setError('Failed to delete photo');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!faceToDelete) return;
+    try {
+      await apiClient.deleteFace(faceToDelete.id);
+      setSuccessMessage(`Face "${faceToDelete.name}" deleted`);
+      setDeleteDialogOpen(false);
+      setFaceToDelete(null);
+      loadFaces();
+    } catch (err: any) {
+      setError('Failed to delete face');
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* Header */}
+      <Paper
+        elevation={0}
+        sx={{
+          p: 2,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Typography variant="h6">Faces</Typography>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => {
+            setNewName('');
+            setCapturedPhotos([]);
+            setCreateDialogOpen(true);
+          }}
+        >
+          Register Face
+        </Button>
+      </Paper>
+
+      {/* Content */}
+      <Box sx={{ flex: 1, overflow: 'auto', p: 3, backgroundColor: '#F7F7F8' }}>
+        {successMessage && (
+          <Alert severity="success" sx={{ mb: 3, maxWidth: 1200, mx: 'auto' }}>
+            {successMessage}
+          </Alert>
+        )}
+        {(error || visionError) && (
+          <Alert
+            severity="error"
+            sx={{ mb: 3, maxWidth: 1200, mx: 'auto' }}
+            onClose={() => setError('')}
+          >
+            {error || visionError}
+          </Alert>
+        )}
+
+        {/* Vision Controls */}
+        <Paper sx={{ p: 2, mb: 3, maxWidth: 1200, mx: 'auto' }}>
+          <Typography variant="subtitle1" gutterBottom>
+            Live Vision
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', flexWrap: 'wrap' }}>
+            <FormControl size="small" sx={{ minWidth: 200 }}>
+              <InputLabel>Webcam</InputLabel>
+              <Select
+                value={selectedWebcam}
+                label="Webcam"
+                onChange={(e) => setSelectedWebcam(e.target.value)}
+                disabled={visionActive}
+              >
+                {webcams.map((cam) => (
+                  <MenuItem key={cam} value={cam}>
+                    {cam}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <Tooltip title="Refresh webcam list">
+              <IconButton onClick={loadWebcams} disabled={visionActive}>
+                <RefreshIcon />
+              </IconButton>
+            </Tooltip>
+            <FormControlLabel
+              control={<Switch checked={enableFace} onChange={(e) => setEnableFace(e.target.checked)} size="small" />}
+              label="Face"
+              disabled={visionActive}
+            />
+            <FormControlLabel
+              control={<Switch checked={enablePose} onChange={(e) => setEnablePose(e.target.checked)} size="small" />}
+              label="Pose"
+              disabled={visionActive}
+            />
+            <FormControlLabel
+              control={<Switch checked={enableHands} onChange={(e) => setEnableHands(e.target.checked)} size="small" />}
+              label="Hands"
+              disabled={visionActive}
+            />
+            <Button
+              variant={visionActive ? 'outlined' : 'contained'}
+              color={visionActive ? 'error' : 'primary'}
+              startIcon={visionActive ? <VideocamOffIcon /> : <VideocamIcon />}
+              onClick={visionActive ? stopVision : startVision}
+              disabled={!selectedWebcam && !visionActive}
+            >
+              {visionActive ? 'Stop Vision' : 'Start Vision'}
+            </Button>
+          </Box>
+
+          {visionActive && !latestResult && (
+            <Box sx={{ mt: 2 }}>
+              <Divider sx={{ mb: 1 }} />
+              <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center', py: 3 }}>
+                Connecting to vision pipeline... Waiting for first frame.
+              </Typography>
+            </Box>
+          )}
+
+          {visionActive && latestResult && (
+            <Box sx={{ mt: 2 }}>
+              <Divider sx={{ mb: 1 }} />
+
+              {/* Debug frame visualization */}
+              {latestResult.debug_frame && (
+                <Box
+                  sx={{
+                    mb: 2,
+                    display: 'flex',
+                    justifyContent: 'center',
+                    bgcolor: 'black',
+                    borderRadius: 2,
+                    overflow: 'hidden',
+                  }}
+                >
+                  <img
+                    src={`data:image/jpeg;base64,${latestResult.debug_frame}`}
+                    alt="Vision debug"
+                    style={{ maxWidth: '100%', maxHeight: 400, objectFit: 'contain' }}
+                  />
+                </Box>
+              )}
+
+              <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap' }}>
+                <Box>
+                  <Typography variant="caption" color="text.secondary">
+                    Detected Faces
+                  </Typography>
+                  <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mt: 0.5 }}>
+                    {latestResult.faces.length === 0 ? (
+                      <Typography variant="body2" color="text.secondary">
+                        None
+                      </Typography>
+                    ) : (
+                      latestResult.faces.map((face, i) => (
+                        <Chip
+                          key={i}
+                          icon={<PersonIcon />}
+                          label={`${face.name} (${Math.round(face.confidence * 100)}%)`}
+                          size="small"
+                          color={face.identity_id ? 'success' : 'default'}
+                          variant="outlined"
+                        />
+                      ))
+                    )}
+                  </Box>
+                </Box>
+                <Box>
+                  <Typography variant="caption" color="text.secondary">
+                    Detected Gestures
+                  </Typography>
+                  <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mt: 0.5 }}>
+                    {latestResult.gestures.length === 0 ? (
+                      <Typography variant="body2" color="text.secondary">
+                        None
+                      </Typography>
+                    ) : (
+                      latestResult.gestures.map((g, i) => (
+                        <Chip
+                          key={i}
+                          label={`${g.gesture} (${Math.round(g.confidence * 100)}%)`}
+                          size="small"
+                          color="primary"
+                          variant="outlined"
+                        />
+                      ))
+                    )}
+                  </Box>
+                </Box>
+              </Box>
+            </Box>
+          )}
+        </Paper>
+
+        {/* Faces Grid */}
+        {loading ? (
+          <Typography sx={{ textAlign: 'center', mt: 4 }}>Loading faces...</Typography>
+        ) : faces.length === 0 ? (
+          <Paper sx={{ p: 4, textAlign: 'center', maxWidth: 600, mx: 'auto' }}>
+            <Typography variant="h6" gutterBottom>
+              No faces registered
+            </Typography>
+            <Typography color="text.secondary" sx={{ mb: 3 }}>
+              Register faces to enable recognition during live vision. Use your webcam to scan your
+              face from multiple angles.
+            </Typography>
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={() => {
+                setNewName('');
+                setCapturedPhotos([]);
+                setCreateDialogOpen(true);
+              }}
+            >
+              Register Face
+            </Button>
+          </Paper>
+        ) : (
+          <Grid container spacing={3} sx={{ maxWidth: 1200, mx: 'auto' }}>
+            <AnimatePresence>
+              {faces.map((face) => (
+                <Grid item xs={12} sm={6} md={4} key={face.id}>
+                  <MotionCard
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -20 }}
+                    transition={{ duration: 0.3 }}
+                    onClick={() => handleOpenDetail(face)}
+                    sx={{
+                      cursor: 'pointer',
+                      border: '1px solid',
+                      borderColor: 'divider',
+                      '&:hover': { boxShadow: 3, transform: 'translateY(-2px)' },
+                      transition: 'box-shadow 0.2s, transform 0.2s',
+                    }}
+                  >
+                    <CardContent sx={{ textAlign: 'center', pt: 4 }}>
+                      <Avatar
+                        sx={{
+                          width: 80,
+                          height: 80,
+                          mx: 'auto',
+                          mb: 2,
+                          bgcolor: 'primary.main',
+                          fontSize: '2rem',
+                        }}
+                      >
+                        {face.name[0]?.toUpperCase()}
+                      </Avatar>
+                      <Typography variant="h6" gutterBottom>
+                        {face.name}
+                      </Typography>
+                      <Chip
+                        icon={<PhotoCameraIcon />}
+                        label={`${face.photo_count} photo${face.photo_count !== 1 ? 's' : ''}`}
+                        size="small"
+                        variant="outlined"
+                      />
+                    </CardContent>
+                    <CardActions sx={{ justifyContent: 'center', pb: 2 }}>
+                      <Tooltip title="Delete">
+                        <IconButton
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setFaceToDelete(face);
+                            setDeleteDialogOpen(true);
+                          }}
+                          color="error"
+                        >
+                          <DeleteIcon />
+                        </IconButton>
+                      </Tooltip>
+                    </CardActions>
+                  </MotionCard>
+                </Grid>
+              ))}
+            </AnimatePresence>
+          </Grid>
+        )}
+      </Box>
+
+      {/* Hidden canvas for captures */}
+      <canvas ref={webcamCanvasRef} style={{ display: 'none' }} />
+
+      {/* Create Dialog */}
+      <Dialog open={createDialogOpen} onClose={handleCloseCreate} maxWidth="sm" fullWidth>
+        <DialogTitle>Register New Face</DialogTitle>
+        <DialogContent>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, mt: 1 }}>
+            <TextField
+              label="Person's Name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              fullWidth
+              required
+              helperText="A unique name for this person"
+            />
+
+            {scanning ? (
+              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
+                <Box
+                  sx={{
+                    width: '100%',
+                    maxWidth: 400,
+                    aspectRatio: '4/3',
+                    bgcolor: 'black',
+                    borderRadius: 2,
+                    overflow: 'hidden',
+                  }}
+                >
+                  <video
+                    ref={webcamVideoRef}
+                    autoPlay
+                    playsInline
+                    muted
+                    style={{ width: '100%', height: '100%', objectFit: 'cover', transform: 'scaleX(-1)' }}
+                  />
+                </Box>
+                <Box sx={{ display: 'flex', gap: 2 }}>
+                  <Button
+                    variant="contained"
+                    startIcon={<CameraAltIcon />}
+                    onClick={handleCapture}
+                    disabled={!webcamStream}
+                  >
+                    Capture
+                  </Button>
+                  <Button variant="outlined" onClick={handleStopScan}>
+                    Stop Camera
+                  </Button>
+                </Box>
+              </Box>
+            ) : (
+              <Button
+                variant="outlined"
+                startIcon={<CameraAltIcon />}
+                onClick={handleStartScan}
+                sx={{ alignSelf: 'flex-start' }}
+              >
+                Scan Face
+              </Button>
+            )}
+
+            {/* Captured photos grid */}
+            {capturedPhotos.length > 0 && (
+              <Box>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                  Captured photos ({capturedPhotos.length})
+                </Typography>
+                <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                  {capturedPhotos.map((photo, i) => (
+                    <Box
+                      key={i}
+                      sx={{
+                        position: 'relative',
+                        width: 80,
+                        height: 80,
+                        borderRadius: 1,
+                        overflow: 'hidden',
+                        border: '1px solid',
+                        borderColor: 'divider',
+                      }}
+                    >
+                      <img
+                        src={photo.preview}
+                        alt={`Capture ${i + 1}`}
+                        style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                      />
+                      <IconButton
+                        size="small"
+                        onClick={() => handleRemoveCapture(i)}
+                        sx={{
+                          position: 'absolute',
+                          top: -4,
+                          right: -4,
+                          bgcolor: 'error.main',
+                          color: 'white',
+                          p: '2px',
+                          '&:hover': { bgcolor: 'error.dark' },
+                        }}
+                      >
+                        <CloseIcon sx={{ fontSize: 14 }} />
+                      </IconButton>
+                    </Box>
+                  ))}
+                </Box>
+              </Box>
+            )}
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseCreate}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={handleCreate}
+            disabled={!newName.trim() || capturedPhotos.length === 0 || creating}
+          >
+            {creating ? 'Registering...' : `Register (${capturedPhotos.length} photo${capturedPhotos.length !== 1 ? 's' : ''})`}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Detail Dialog */}
+      <Dialog open={detailDialogOpen} onClose={handleCloseDetail} maxWidth="md" fullWidth>
+        <DialogTitle>{selectedFace?.name} - Photos</DialogTitle>
+        <DialogContent>
+          {selectedFace && (
+            <Box>
+              <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 1 }}>
+                {selectedFace.photos.map((photo) => (
+                  <Box
+                    key={photo.id}
+                    sx={{
+                      position: 'relative',
+                      width: 120,
+                      height: 120,
+                      borderRadius: 2,
+                      overflow: 'hidden',
+                      border: '1px solid',
+                      borderColor: 'divider',
+                    }}
+                  >
+                    <img
+                      src={apiClient.getImageUrl(photo.photo_uuid)}
+                      alt="Face photo"
+                      style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                    />
+                    <IconButton
+                      size="small"
+                      color="error"
+                      onClick={() => handleDeletePhoto(photo.id)}
+                      sx={{
+                        position: 'absolute',
+                        top: 2,
+                        right: 2,
+                        bgcolor: 'rgba(255,255,255,0.8)',
+                        '&:hover': { bgcolor: 'rgba(255,255,255,0.95)' },
+                      }}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </Box>
+                ))}
+              </Box>
+
+              <Divider sx={{ my: 2 }} />
+
+              {detailScanning ? (
+                <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
+                  <Box
+                    sx={{
+                      width: '100%',
+                      maxWidth: 320,
+                      aspectRatio: '4/3',
+                      bgcolor: 'black',
+                      borderRadius: 2,
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <video
+                      ref={webcamVideoRef}
+                      autoPlay
+                      playsInline
+                      muted
+                      style={{ width: '100%', height: '100%', objectFit: 'cover', transform: 'scaleX(-1)' }}
+                    />
+                  </Box>
+                  <Box sx={{ display: 'flex', gap: 2 }}>
+                    <Button
+                      variant="contained"
+                      startIcon={<CameraAltIcon />}
+                      onClick={handleDetailCapture}
+                      disabled={!webcamStream}
+                    >
+                      Capture & Add
+                    </Button>
+                    <Button variant="outlined" onClick={handleDetailStopScan}>
+                      Stop Camera
+                    </Button>
+                  </Box>
+                </Box>
+              ) : (
+                <Button
+                  variant="outlined"
+                  startIcon={<CameraAltIcon />}
+                  onClick={handleDetailStartScan}
+                >
+                  Scan Face
+                </Button>
+              )}
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDetail}>Close</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={deleteDialogOpen} onClose={() => setDeleteDialogOpen(false)}>
+        <DialogTitle>Delete Face</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete "{faceToDelete?.name}"? This will remove all associated
+            photos. This action cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteDialogOpen(false)}>Cancel</Button>
+          <Button variant="contained" color="error" onClick={handleDelete}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};

--- a/src/components/FacesWindow.tsx
+++ b/src/components/FacesWindow.tsx
@@ -62,10 +62,14 @@ export const FacesWindow: React.FC = () => {
   const [scanning, setScanning] = useState(false);
   const [creating, setCreating] = useState(false);
 
-  // Webcam
+  // Webcam (face registration scanning)
   const [webcamStream, setWebcamStream] = useState<MediaStream | null>(null);
   const webcamVideoRef = useRef<HTMLVideoElement>(null);
   const webcamCanvasRef = useRef<HTMLCanvasElement>(null);
+
+  // Vision preview (detection overlay on store's stream)
+  const visionVideoRef = useRef<HTMLVideoElement>(null);
+  const visionCanvasRef = useRef<HTMLCanvasElement>(null);
 
   // Detail dialog
   const [detailDialogOpen, setDetailDialogOpen] = useState(false);
@@ -79,6 +83,7 @@ export const FacesWindow: React.FC = () => {
   // Vision
   const {
     isActive: visionActive,
+    stream: visionStream,
     latestResult,
     webcams,
     selectedWebcam,
@@ -118,6 +123,61 @@ export const FacesWindow: React.FC = () => {
       return () => clearTimeout(timer);
     }
   }, [successMessage]);
+
+  // Attach store's vision stream to video element for preview
+  useEffect(() => {
+    if (visionVideoRef.current) {
+      visionVideoRef.current.srcObject = visionStream;
+    }
+  }, [visionStream]);
+
+  // Draw detection overlay on vision canvas
+  useEffect(() => {
+    const canvas = visionCanvasRef.current;
+    const video = visionVideoRef.current;
+    if (!canvas || !video || !visionActive || !latestResult) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    // Match canvas size to video
+    canvas.width = video.videoWidth || 640;
+    canvas.height = video.videoHeight || 480;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    const w = canvas.width;
+    const h = canvas.height;
+
+    // Draw face bounding boxes
+    for (const face of latestResult.faces) {
+      const [x1, y1, x2, y2] = face.bbox;
+      const color = face.identity_id ? '#00c853' : '#ff9100';
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 2;
+      ctx.strokeRect(x1, y1, x2 - x1, y2 - y1);
+
+      // Label
+      const label = `${face.name} (${Math.round(face.confidence * 100)}%)`;
+      ctx.font = '14px sans-serif';
+      const tw = ctx.measureText(label).width;
+      ctx.fillStyle = color;
+      ctx.fillRect(x1, y1 - 20, tw + 8, 20);
+      ctx.fillStyle = '#fff';
+      ctx.fillText(label, x1 + 4, y1 - 5);
+    }
+
+    // Draw gesture labels
+    for (let i = 0; i < latestResult.gestures.length; i++) {
+      const g = latestResult.gestures[i];
+      const label = `${g.gesture} (${Math.round(g.confidence * 100)}%)`;
+      ctx.font = 'bold 16px sans-serif';
+      const tw = ctx.measureText(label).width;
+      ctx.fillStyle = 'rgba(0,0,0,0.5)';
+      ctx.fillRect(w - tw - 16, 10 + i * 30, tw + 12, 24);
+      ctx.fillStyle = '#00e5ff';
+      ctx.fillText(label, w - tw - 10, 28 + i * 30);
+    }
+  }, [latestResult, visionActive]);
 
   const startWebcam = useCallback(async () => {
     try {
@@ -376,86 +436,91 @@ export const FacesWindow: React.FC = () => {
             </Button>
           </Box>
 
-          {visionActive && !latestResult && (
-            <Box sx={{ mt: 2 }}>
-              <Divider sx={{ mb: 1 }} />
-              <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center', py: 3 }}>
-                Connecting to vision pipeline... Waiting for first frame.
-              </Typography>
-            </Box>
-          )}
-
-          {visionActive && latestResult && (
+          {visionActive && (
             <Box sx={{ mt: 2 }}>
               <Divider sx={{ mb: 1 }} />
 
-              {/* Debug frame visualization */}
-              {latestResult.debug_frame && (
-                <Box
-                  sx={{
-                    mb: 2,
-                    display: 'flex',
-                    justifyContent: 'center',
-                    bgcolor: 'black',
-                    borderRadius: 2,
-                    overflow: 'hidden',
+              {/* Live webcam preview with detection overlay */}
+              <Box
+                sx={{
+                  mb: 2,
+                  display: 'flex',
+                  justifyContent: 'center',
+                  bgcolor: 'black',
+                  borderRadius: 2,
+                  overflow: 'hidden',
+                  position: 'relative',
+                }}
+              >
+                <video
+                  ref={visionVideoRef}
+                  autoPlay
+                  playsInline
+                  muted
+                  style={{ maxWidth: '100%', maxHeight: 400, objectFit: 'contain' }}
+                />
+                <canvas
+                  ref={visionCanvasRef}
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    height: '100%',
+                    pointerEvents: 'none',
                   }}
-                >
-                  <img
-                    src={`data:image/jpeg;base64,${latestResult.debug_frame}`}
-                    alt="Vision debug"
-                    style={{ maxWidth: '100%', maxHeight: 400, objectFit: 'contain' }}
-                  />
+                />
+              </Box>
+
+              {latestResult && (
+                <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap' }}>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">
+                      Detected Faces
+                    </Typography>
+                    <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mt: 0.5 }}>
+                      {latestResult.faces.length === 0 ? (
+                        <Typography variant="body2" color="text.secondary">
+                          None
+                        </Typography>
+                      ) : (
+                        latestResult.faces.map((face, i) => (
+                          <Chip
+                            key={i}
+                            icon={<PersonIcon />}
+                            label={`${face.name} (${Math.round(face.confidence * 100)}%)`}
+                            size="small"
+                            color={face.identity_id ? 'success' : 'default'}
+                            variant="outlined"
+                          />
+                        ))
+                      )}
+                    </Box>
+                  </Box>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">
+                      Detected Gestures
+                    </Typography>
+                    <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mt: 0.5 }}>
+                      {latestResult.gestures.length === 0 ? (
+                        <Typography variant="body2" color="text.secondary">
+                          None
+                        </Typography>
+                      ) : (
+                        latestResult.gestures.map((g, i) => (
+                          <Chip
+                            key={i}
+                            label={`${g.gesture} (${Math.round(g.confidence * 100)}%)`}
+                            size="small"
+                            color="primary"
+                            variant="outlined"
+                          />
+                        ))
+                      )}
+                    </Box>
+                  </Box>
                 </Box>
               )}
-
-              <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap' }}>
-                <Box>
-                  <Typography variant="caption" color="text.secondary">
-                    Detected Faces
-                  </Typography>
-                  <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mt: 0.5 }}>
-                    {latestResult.faces.length === 0 ? (
-                      <Typography variant="body2" color="text.secondary">
-                        None
-                      </Typography>
-                    ) : (
-                      latestResult.faces.map((face, i) => (
-                        <Chip
-                          key={i}
-                          icon={<PersonIcon />}
-                          label={`${face.name} (${Math.round(face.confidence * 100)}%)`}
-                          size="small"
-                          color={face.identity_id ? 'success' : 'default'}
-                          variant="outlined"
-                        />
-                      ))
-                    )}
-                  </Box>
-                </Box>
-                <Box>
-                  <Typography variant="caption" color="text.secondary">
-                    Detected Gestures
-                  </Typography>
-                  <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mt: 0.5 }}>
-                    {latestResult.gestures.length === 0 ? (
-                      <Typography variant="body2" color="text.secondary">
-                        None
-                      </Typography>
-                    ) : (
-                      latestResult.gestures.map((g, i) => (
-                        <Chip
-                          key={i}
-                          label={`${g.gesture} (${Math.round(g.confidence * 100)}%)`}
-                          size="small"
-                          color="primary"
-                          variant="outlined"
-                        />
-                      ))
-                    )}
-                  </Box>
-                </Box>
-              </Box>
             </Box>
           )}
         </Paper>

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -40,15 +40,16 @@ import { ChatWidget } from './ChatWidget';
 import { SettingsWindow } from './SettingsWindow';
 import { AgentsWindow } from './AgentsWindow';
 import { ToolsWindow } from './ToolsWindow';
+import { FacesWindow } from './FacesWindow';
 
 const DRAWER_WIDTH = 280;
 
 const MotionListItemButton = motion(ListItemButton);
 
-type Page = 'chat' | 'settings' | 'agents' | 'tools';
+type Page = 'chat' | 'settings' | 'agents' | 'tools' | 'faces';
 
-const TAB_TO_PAGE: Page[] = ['chat', 'agents', 'tools'];
-const PAGE_TO_TAB: Record<string, number> = { chat: 0, agents: 1, tools: 2 };
+const TAB_TO_PAGE: Page[] = ['chat', 'agents', 'tools', 'faces'];
+const PAGE_TO_TAB: Record<string, number> = { chat: 0, agents: 1, tools: 2, faces: 3 };
 
 export const MainWindow: React.FC = () => {
   const { user, logout } = useAuthStore();
@@ -154,6 +155,7 @@ export const MainWindow: React.FC = () => {
           <Tab icon={<ChatIcon fontSize="small" />} label="Chat" iconPosition="start" />
           <Tab icon={<AgentsIcon fontSize="small" />} label="Agents" iconPosition="start" />
           <Tab icon={<ToolsIcon fontSize="small" />} label="Tools" iconPosition="start" />
+          <Tab icon={<FaceIcon fontSize="small" />} label="Faces" iconPosition="start" />
         </Tabs>
         <Box sx={{ flex: 1 }} />
         <Typography variant="body2" color="text.secondary" sx={{ mr: 1 }}>
@@ -316,6 +318,9 @@ export const MainWindow: React.FC = () => {
           </Box>
           <Box sx={{ flex: 1, display: currentPage === 'tools' ? 'flex' : 'none', flexDirection: 'column', overflow: 'hidden' }}>
             <ToolsWindow />
+          </Box>
+          <Box sx={{ flex: 1, display: currentPage === 'faces' ? 'flex' : 'none', flexDirection: 'column', overflow: 'hidden' }}>
+            <FacesWindow />
           </Box>
           {currentPage === 'settings' && (
             <SettingsWindow onBack={() => setCurrentPage('chat')} />

--- a/src/store/visionStore.ts
+++ b/src/store/visionStore.ts
@@ -2,10 +2,12 @@ import { create } from 'zustand';
 import { wsManager, VisionResultEvent } from '../api/websocket';
 import type { VisionResult } from '../api/types';
 
-const DEFAULT_RTSP_URL = 'rtsp://localhost:8554/webcam';
+const DETECT_FPS = 5;
+const DETECT_INTERVAL = 1000 / DETECT_FPS;
 
 interface VisionState {
   isActive: boolean;
+  stream: MediaStream | null;
   latestResult: VisionResult | null;
   webcams: string[];
   selectedWebcam: string;
@@ -16,17 +18,63 @@ interface VisionState {
 
   loadWebcams: () => Promise<void>;
   startVision: () => Promise<void>;
-  stopVision: () => Promise<void>;
+  stopVision: () => void;
   setSelectedWebcam: (webcam: string) => void;
   setEnableFace: (enabled: boolean) => void;
   setEnablePose: (enabled: boolean) => void;
   setEnableHands: (enabled: boolean) => void;
 }
 
-let _active = false;
+// Module-level state for frame capture (not in Zustand to avoid re-renders)
+let _captureInterval: ReturnType<typeof setInterval> | null = null;
+let _hiddenVideo: HTMLVideoElement | null = null;
+let _hiddenCanvas: HTMLCanvasElement | null = null;
+
+function _stopCapture() {
+  if (_captureInterval) {
+    clearInterval(_captureInterval);
+    _captureInterval = null;
+  }
+  if (_hiddenVideo) {
+    _hiddenVideo.srcObject = null;
+    _hiddenVideo.remove();
+    _hiddenVideo = null;
+  }
+  if (_hiddenCanvas) {
+    _hiddenCanvas.remove();
+    _hiddenCanvas = null;
+  }
+}
+
+function _startCapture(stream: MediaStream) {
+  _stopCapture();
+
+  _hiddenVideo = document.createElement('video');
+  _hiddenVideo.srcObject = stream;
+  _hiddenVideo.muted = true;
+  _hiddenVideo.playsInline = true;
+  _hiddenVideo.play();
+
+  _hiddenCanvas = document.createElement('canvas');
+
+  _captureInterval = setInterval(() => {
+    if (!_hiddenVideo || !_hiddenCanvas || _hiddenVideo.readyState < 2) return;
+
+    _hiddenCanvas.width = _hiddenVideo.videoWidth;
+    _hiddenCanvas.height = _hiddenVideo.videoHeight;
+    const ctx = _hiddenCanvas.getContext('2d');
+    if (!ctx) return;
+
+    ctx.drawImage(_hiddenVideo, 0, 0);
+    const dataUrl = _hiddenCanvas.toDataURL('image/jpeg', 0.7);
+    const base64 = dataUrl.split(',')[1];
+    wsManager.sendVisionFrame(base64);
+  }, DETECT_INTERVAL);
+}
 
 export const useVisionStore = create<VisionState>((set, get) => ({
   isActive: false,
+  stream: null,
   latestResult: null,
   webcams: [],
   selectedWebcam: '',
@@ -50,16 +98,10 @@ export const useVisionStore = create<VisionState>((set, get) => ({
   },
 
   startVision: async () => {
-    if (_active) return;
+    if (get().isActive) return;
     set({ error: '' });
 
     const { selectedWebcam, enableFace, enablePose, enableHands } = get();
-
-    const api = window.electron?.vision;
-    if (!api) {
-      set({ error: 'Vision API not available (requires Electron)' });
-      return;
-    }
 
     if (!selectedWebcam) {
       set({ error: 'No webcam selected' });
@@ -67,35 +109,49 @@ export const useVisionStore = create<VisionState>((set, get) => ({
     }
 
     try {
-      const rtspUrl = DEFAULT_RTSP_URL;
-      await api.start(selectedWebcam, rtspUrl);
-      await wsManager.sendVisionStart(rtspUrl, {
+      // Find deviceId matching the selected webcam label
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      const match = devices.find(
+        (d) => d.kind === 'videoinput' && (d.label === selectedWebcam || d.label.startsWith(selectedWebcam))
+      );
+
+      const constraints: MediaStreamConstraints = {
+        video: {
+          width: 640,
+          height: 480,
+          ...(match?.deviceId ? { deviceId: { exact: match.deviceId } } : {}),
+        },
+      };
+
+      const stream = await navigator.mediaDevices.getUserMedia(constraints);
+
+      // Tell backend to start processing
+      await wsManager.sendVisionStart({
         enable_face: enableFace,
         enable_pose: enablePose,
         enable_hands: enableHands,
       });
-      _active = true;
-      set({ isActive: true });
+
+      // Start frame capture interval
+      _startCapture(stream);
+
+      set({ isActive: true, stream });
     } catch (err: any) {
       set({ error: `Failed to start vision: ${err.message}` });
     }
   },
 
-  stopVision: async () => {
-    if (!_active) return;
+  stopVision: () => {
+    const { stream } = get();
 
-    try {
-      wsManager.sendVisionStop();
-      const api = window.electron?.vision;
-      if (api) {
-        await api.stop();
-      }
-    } catch (err: any) {
-      console.error('Failed to stop vision:', err);
-    } finally {
-      _active = false;
-      set({ isActive: false, latestResult: null });
+    _stopCapture();
+    wsManager.sendVisionStop();
+
+    if (stream) {
+      stream.getTracks().forEach((t) => t.stop());
     }
+
+    set({ isActive: false, stream: null, latestResult: null });
   },
 
   setSelectedWebcam: (webcam: string) => set({ selectedWebcam: webcam }),
@@ -117,7 +173,6 @@ wsManager.on('vision_result', (event: VisionResultEvent) => {
     latestResult: {
       faces: event.faces,
       gestures: event.gestures,
-      debug_frame: event.debug_frame,
     },
   });
 

--- a/src/store/visionStore.ts
+++ b/src/store/visionStore.ts
@@ -1,0 +1,129 @@
+import { create } from 'zustand';
+import { wsManager, VisionResultEvent } from '../api/websocket';
+import type { VisionResult } from '../api/types';
+
+const DEFAULT_RTSP_URL = 'rtsp://localhost:8554/webcam';
+
+interface VisionState {
+  isActive: boolean;
+  latestResult: VisionResult | null;
+  webcams: string[];
+  selectedWebcam: string;
+  enableFace: boolean;
+  enablePose: boolean;
+  enableHands: boolean;
+  error: string;
+
+  loadWebcams: () => Promise<void>;
+  startVision: () => Promise<void>;
+  stopVision: () => Promise<void>;
+  setSelectedWebcam: (webcam: string) => void;
+  setEnableFace: (enabled: boolean) => void;
+  setEnablePose: (enabled: boolean) => void;
+  setEnableHands: (enabled: boolean) => void;
+}
+
+let _active = false;
+
+export const useVisionStore = create<VisionState>((set, get) => ({
+  isActive: false,
+  latestResult: null,
+  webcams: [],
+  selectedWebcam: '',
+  enableFace: true,
+  enablePose: true,
+  enableHands: true,
+  error: '',
+
+  loadWebcams: async () => {
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      const videoDevices = devices.filter((d) => d.kind === 'videoinput');
+      const names = videoDevices.map((d) => d.label || `Camera ${d.deviceId.slice(0, 8)}`);
+      set({ webcams: names });
+      if (names.length > 0 && !get().selectedWebcam) {
+        set({ selectedWebcam: names[0] });
+      }
+    } catch (err: any) {
+      set({ error: `Failed to list webcams: ${err.message}` });
+    }
+  },
+
+  startVision: async () => {
+    if (_active) return;
+    set({ error: '' });
+
+    const { selectedWebcam, enableFace, enablePose, enableHands } = get();
+
+    const api = window.electron?.vision;
+    if (!api) {
+      set({ error: 'Vision API not available (requires Electron)' });
+      return;
+    }
+
+    if (!selectedWebcam) {
+      set({ error: 'No webcam selected' });
+      return;
+    }
+
+    try {
+      const rtspUrl = DEFAULT_RTSP_URL;
+      await api.start(selectedWebcam, rtspUrl);
+      await wsManager.sendVisionStart(rtspUrl, {
+        enable_face: enableFace,
+        enable_pose: enablePose,
+        enable_hands: enableHands,
+      });
+      _active = true;
+      set({ isActive: true });
+    } catch (err: any) {
+      set({ error: `Failed to start vision: ${err.message}` });
+    }
+  },
+
+  stopVision: async () => {
+    if (!_active) return;
+
+    try {
+      wsManager.sendVisionStop();
+      const api = window.electron?.vision;
+      if (api) {
+        await api.stop();
+      }
+    } catch (err: any) {
+      console.error('Failed to stop vision:', err);
+    } finally {
+      _active = false;
+      set({ isActive: false, latestResult: null });
+    }
+  },
+
+  setSelectedWebcam: (webcam: string) => set({ selectedWebcam: webcam }),
+  setEnableFace: (enabled: boolean) => set({ enableFace: enabled }),
+  setEnablePose: (enabled: boolean) => set({ enablePose: enabled }),
+  setEnableHands: (enabled: boolean) => set({ enableHands: enabled }),
+}));
+
+// Module-level WebSocket listener — singleton, runs for app lifetime
+wsManager.on('vision_result', (event: VisionResultEvent) => {
+  if (event.faces.length > 0) {
+    console.log('[vision] faces:', event.faces.map((f) => `${f.name} (${Math.round(f.confidence * 100)}%)`).join(', '));
+  }
+  if (event.gestures.length > 0) {
+    console.log('[vision] gestures:', event.gestures.map((g) => `${g.gesture} (${Math.round(g.confidence * 100)}%)`).join(', '));
+  }
+
+  useVisionStore.setState({
+    latestResult: {
+      faces: event.faces,
+      gestures: event.gestures,
+      debug_frame: event.debug_frame,
+    },
+  });
+
+  // Forward gestures to character window via IPC
+  if (event.gestures.length > 0) {
+    const gestureNames = event.gestures.map((g) => g.gesture);
+    window.electron?.characterWindow?.sendGestureUpdate({ gestures: gestureNames });
+  }
+});

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -6,12 +6,6 @@ export interface AgentData {
   poseTree: PoseTree | null;
 }
 
-export interface VisionAPI {
-  start: (webcamName: string, rtspUrl: string) => Promise<{ status: string }>;
-  stop: () => Promise<{ status: string }>;
-  listWebcams: () => Promise<string[]>;
-}
-
 export interface CharacterWindowAPI {
   open: () => Promise<void>;
   close: () => Promise<void>;
@@ -28,7 +22,6 @@ export interface CharacterWindowAPI {
 
 export interface ElectronAPI {
   platform: string;
-  vision: VisionAPI;
   characterWindow: CharacterWindowAPI;
 }
 

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -6,13 +6,21 @@ export interface AgentData {
   poseTree: PoseTree | null;
 }
 
+export interface VisionAPI {
+  start: (webcamName: string, rtspUrl: string) => Promise<{ status: string }>;
+  stop: () => Promise<{ status: string }>;
+  listWebcams: () => Promise<string[]>;
+}
+
 export interface CharacterWindowAPI {
   open: () => Promise<void>;
   close: () => Promise<void>;
   sendAmplitude: (data: { amplitude: number; isPlaying: boolean; isThinking: boolean }) => void;
   sendAgentsUpdate: (data: { agents: AgentData[]; activeAgentId: number | null }) => void;
+  sendGestureUpdate: (data: { gestures: string[] }) => void;
   onAmplitude: (cb: (data: { amplitude: number; isPlaying: boolean; isThinking: boolean }) => void) => () => void;
   onAgentsUpdate: (cb: (data: { agents: AgentData[]; activeAgentId: number | null }) => void) => () => void;
+  onGestureUpdate: (cb: (data: { gestures: string[] }) => void) => () => void;
   onWindowClosed: (cb: () => void) => () => void;
   signalReady: () => void;
   onCharacterReady: (cb: () => void) => () => void;
@@ -20,6 +28,7 @@ export interface CharacterWindowAPI {
 
 export interface ElectronAPI {
   platform: string;
+  vision: VisionAPI;
   characterWindow: CharacterWindowAPI;
 }
 

--- a/src/videocall/CharacterRenderer.tsx
+++ b/src/videocall/CharacterRenderer.tsx
@@ -12,11 +12,13 @@ export interface AmplitudeState {
 interface CharacterRendererProps {
   poseTree: PoseTree | null;
   amplitudeRef: React.RefObject<AmplitudeState>;
+  gesturesRef?: React.RefObject<string[]>;
 }
 
 export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
   poseTree,
   amplitudeRef,
+  gesturesRef,
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const compositorRef = useRef<CanvasCompositor | null>(null);
@@ -42,7 +44,7 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
     }
   }, [poseTree]);
 
-  // Sync amplitude from ref to compositor at ~60fps (no React re-renders)
+  // Sync amplitude + gestures from refs to compositor at ~60fps (no React re-renders)
   useEffect(() => {
     let rafId: number;
     const sync = () => {
@@ -51,11 +53,16 @@ export const CharacterRenderer: React.FC<CharacterRendererProps> = ({
         compositorRef.current.isAudioPlaying = amplitudeRef.current.isPlaying;
         compositorRef.current.isThinking = amplitudeRef.current.isThinking;
       }
+      // Forward gestures (consumed once by compositor)
+      if (compositorRef.current && gesturesRef?.current && gesturesRef.current.length > 0) {
+        compositorRef.current.setGestures(gesturesRef.current);
+        gesturesRef.current = [];
+      }
       rafId = requestAnimationFrame(sync);
     };
     rafId = requestAnimationFrame(sync);
     return () => cancelAnimationFrame(rafId);
-  }, [amplitudeRef]);
+  }, [amplitudeRef, gesturesRef]);
 
   return (
     <canvas

--- a/src/videocall/engine/CanvasCompositor.ts
+++ b/src/videocall/engine/CanvasCompositor.ts
@@ -1,4 +1,5 @@
-import type { PoseConfig, PoseTree, ProcessedPose, LoadedPatch, AnimationEdge, AnimationSettings } from '../types';
+import type { PoseConfig, PoseTree, ProcessedPose, LoadedPatch, AnimationEdge, EdgeTransition, AnimationSettings } from '../types';
+import { migrateEdgeToTransitions } from '../types';
 import { getCachedImage } from './ImageCache';
 
 type BlinkState = 'open' | 'closing' | 'closed' | 'opening';
@@ -51,6 +52,9 @@ export class CanvasCompositor {
   public mouthAmplitude = 0;
   public isAudioPlaying = false;
   public isThinking = false;
+
+  // Active gestures (set externally, cleared after each check cycle)
+  private activeGestures: Set<string> = new Set();
 
   // Manual eye overrides (-1 = auto blink, 0+ = forced patch index)
   public leftEyeOverride = -1;
@@ -107,6 +111,7 @@ export class CanvasCompositor {
       }
       this.updateEdgeTimers(dt);
       this.checkThinkingEdges();
+      this.checkGestureEdges();
     }
     // During transitioning, skip blink/breathing/edge timer updates
   }
@@ -126,41 +131,79 @@ export class CanvasCompositor {
   private updateEdgeTimers(dt: number): void {
     if (!this.poseTree || !this.currentNodeId) return;
 
-    // Tick all timers and collect ready edges
-    const ready: AnimationEdge[] = [];
-    for (const [edgeId, timer] of this.edgeTimers) {
+    // Tick all timers and collect ready (edge, transition) pairs
+    const ready: { edge: AnimationEdge; transition: EdgeTransition }[] = [];
+    for (const [timerKey, timer] of this.edgeTimers) {
       timer.elapsed += dt;
       if (timer.elapsed >= timer.target) {
+        const [edgeId, tiStr] = timerKey.split(':');
         const edge = this.poseTree.edges.find((e) => e.id === edgeId);
-        if (edge) ready.push(edge);
+        if (edge) {
+          const transition = edge.transitions[Number(tiStr)];
+          if (transition) ready.push({ edge, transition });
+        }
       }
     }
 
     if (ready.length > 0) {
-      this.startTransition(ready[Math.floor(Math.random() * ready.length)]);
+      const pick = ready[Math.floor(Math.random() * ready.length)];
+      this.startTransitionFromEdge(pick.edge, pick.transition);
     }
   }
 
   private checkThinkingEdges(): void {
     if (!this.poseTree || !this.currentNodeId) return;
 
-    const matched: AnimationEdge[] = [];
+    const matched: { edge: AnimationEdge; transition: EdgeTransition }[] = [];
     for (const edge of this.poseTree.edges) {
       if (edge.from_node_id !== this.currentNodeId) continue;
-      if (edge.condition?.type !== 'thinking') continue;
-      if (edge.condition.value === this.isThinking) matched.push(edge);
+      for (const transition of edge.transitions) {
+        if (transition.condition.type !== 'thinking') continue;
+        if (transition.condition.value === this.isThinking) {
+          matched.push({ edge, transition });
+        }
+      }
     }
 
     if (matched.length > 0) {
-      this.startTransition(matched[Math.floor(Math.random() * matched.length)]);
+      const pick = matched[Math.floor(Math.random() * matched.length)];
+      this.startTransitionFromEdge(pick.edge, pick.transition);
     }
   }
 
-  private startTransition(edge: AnimationEdge): void {
+  /** Update the set of currently detected gestures (called externally from IPC) */
+  setGestures(gestures: string[]): void {
+    this.activeGestures = new Set(gestures);
+  }
+
+  private checkGestureEdges(): void {
+    if (!this.poseTree || !this.currentNodeId || this.activeGestures.size === 0) return;
+
+    const matched: { edge: AnimationEdge; transition: EdgeTransition }[] = [];
+    for (const edge of this.poseTree.edges) {
+      if (edge.from_node_id !== this.currentNodeId) continue;
+      for (const transition of edge.transitions) {
+        if (transition.condition.type !== 'gesture') continue;
+        if (this.activeGestures.has(transition.condition.value)) {
+          matched.push({ edge, transition });
+        }
+      }
+    }
+
+    // Clear gestures after checking (gestures are instantaneous events)
+    this.activeGestures.clear();
+
+    if (matched.length > 0) {
+      const pick = matched[Math.floor(Math.random() * matched.length)];
+      this.startTransitionFromEdge(pick.edge, pick.transition);
+    }
+  }
+
+  private startTransitionFromEdge(edge: AnimationEdge, transition: EdgeTransition): void {
     this.captureForCrossfade();
 
-    // Pick a random video from the list (if any)
-    const urls = edge.video_urls;
+    // Pick a random video from the transition's list (if any)
+    const urls = transition.video_urls;
     const videoUrl = urls?.length
       ? urls[Math.floor(Math.random() * urls.length)]
       : undefined;
@@ -180,7 +223,7 @@ export class CanvasCompositor {
       const video = document.createElement('video');
       video.muted = true;
       video.playsInline = true;
-      video.playbackRate = edge.playback_rate ?? 1.0;
+      video.playbackRate = transition.playback_rate ?? 1.0;
       this.transitionVideo = video;
 
       let settled = false;
@@ -247,12 +290,14 @@ export class CanvasCompositor {
 
     for (const edge of this.poseTree.edges) {
       if (edge.from_node_id !== this.currentNodeId) continue;
-      if (!edge.condition) continue;
 
-      if (edge.condition.type === 'random') {
-        const { min_interval_ms, max_interval_ms } = edge.condition;
-        const target = min_interval_ms + Math.random() * (max_interval_ms - min_interval_ms);
-        this.edgeTimers.set(edge.id, { elapsed: 0, target });
+      for (let ti = 0; ti < edge.transitions.length; ti++) {
+        const transition = edge.transitions[ti];
+        if (transition.condition.type === 'random') {
+          const { min_interval_ms, max_interval_ms } = transition.condition;
+          const target = min_interval_ms + Math.random() * (max_interval_ms - min_interval_ms);
+          this.edgeTimers.set(`${edge.id}:${ti}`, { elapsed: 0, target });
+        }
       }
     }
   }
@@ -435,21 +480,18 @@ export class CanvasCompositor {
       this.transitionVideo = null;
     }
 
-    // Migrate legacy thinking trigger → value
-    for (const edge of poseTree.edges) {
-      if (edge.condition?.type === 'thinking' && !('value' in edge.condition)) {
-        const legacy = edge.condition as any;
-        edge.condition = { type: 'thinking', value: legacy.trigger === 'start' };
-      }
-    }
+    // Migrate legacy edges to transitions[] format
+    poseTree.edges = poseTree.edges.map((e) => migrateEdgeToTransitions(e));
 
-    // Collect all unique video URLs from edges
+    // Collect all unique video URLs from edge transitions
     const resolveUrl = (url: string) =>
       url.startsWith('http') ? url : `${apiBaseUrl}${url}`;
     const videoUrls = new Set<string>();
     for (const edge of poseTree.edges) {
-      for (const url of edge.video_urls || []) {
-        videoUrls.add(resolveUrl(url));
+      for (const transition of edge.transitions) {
+        for (const url of transition.video_urls || []) {
+          videoUrls.add(resolveUrl(url));
+        }
       }
     }
 

--- a/src/videocall/types.ts
+++ b/src/videocall/types.ts
@@ -55,8 +55,14 @@ export interface ThinkingCondition {
   value: boolean;  // true = fires when thinking, false = fires when not thinking
 }
 
-// Extensible union — add KeywordCondition, TimeCondition, CameraCondition later
-export type TransitionCondition = RandomCondition | ThinkingCondition;
+/** Gesture condition — fires when a specific gesture is detected via camera */
+export interface GestureCondition {
+  type: 'gesture';
+  value: string;  // gesture name: "wave", "thumbs_up", "peace_sign", "pointing", "open_palm"
+}
+
+// Extensible union
+export type TransitionCondition = RandomCondition | ThinkingCondition | GestureCondition;
 
 // ─── Animation Graph ───
 
@@ -70,14 +76,19 @@ export interface AnimationNode {
   position: { x: number; y: number };  // Canvas position for React Flow persistence
 }
 
-/** A directed edge = a video transition between two nodes */
+/** A single transition within an edge — each has its own condition, videos, and playback rate */
+export interface EdgeTransition {
+  condition: TransitionCondition;
+  video_urls?: string[];
+  playback_rate?: number;         // 0.25-4x, default 1.0
+}
+
+/** A directed edge between two nodes, containing one or more transitions */
 export interface AnimationEdge {
   id: string;
   from_node_id: string;
   to_node_id: string;
-  video_urls?: string[];          // Multiple video clips — one chosen at random during playback
-  condition?: TransitionCondition;
-  playback_rate?: number;         // 0.25-4x, default 1.0
+  transitions: EdgeTransition[];
 }
 
 /** Configurable animation timing for a pose node */
@@ -103,4 +114,41 @@ export interface PoseTree {
 export interface CharacterConfig {
   agent_id: number;
   pose_tree: PoseTree;
+}
+
+// ─── Migration ───
+
+/** Migrate a legacy edge (single condition/video_urls/playback_rate) to transitions[] format */
+export function migrateEdgeToTransitions(edge: any): AnimationEdge {
+  // Already migrated
+  if (Array.isArray(edge.transitions) && edge.transitions.length > 0) {
+    return edge as AnimationEdge;
+  }
+
+  // Migrate legacy video_url (string) → video_urls (array)
+  let videoUrls: string[] | undefined = edge.video_urls;
+  if (!videoUrls?.length && edge.video_url) {
+    videoUrls = [edge.video_url];
+  }
+
+  // Migrate legacy thinking trigger → value
+  let condition: TransitionCondition = edge.condition;
+  if (condition?.type === 'thinking' && !('value' in condition)) {
+    const legacy = condition as any;
+    condition = { type: 'thinking', value: legacy.trigger === 'start' };
+  }
+
+  // Build single transition from legacy fields
+  const transition: EdgeTransition = {
+    condition: condition || { type: 'random', min_interval_ms: 5000, max_interval_ms: 15000 },
+    video_urls: videoUrls,
+    playback_rate: edge.playback_rate,
+  };
+
+  return {
+    id: edge.id,
+    from_node_id: edge.from_node_id,
+    to_node_id: edge.to_node_id,
+    transitions: [transition],
+  };
 }


### PR DESCRIPTION
## Summary
- Add webcam capture via getUserMedia with frame upload over WebSocket (3 FPS)
- Add vision store managing face/gesture detection state and WebSocket events
- Add Faces management window (register, view, delete face identities and photos)
- Add camera toggle in chat widget, gesture-driven character animation via CanvasCompositor edge transitions

## Test plan
- [ ] Toggle camera in chat widget — verify webcam preview appears and frames are sent
- [ ] Open Faces window — register a face, verify it appears in the list
- [ ] Add additional photos to an existing face identity
- [ ] Delete a face identity and verify cleanup
- [ ] Verify gesture results from backend trigger character animation transitions
- [ ] Verify WebSocket reconnection replays vision state correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)