### PR TITLE
Add media player UI, skills management, and frame separators

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,15 +22,17 @@ GitHub Actions workflow (`.github/workflows/build.yml`): triggers on release cre
 ```
 electron/main.ts          — Multi-window Electron entry (main + character window)
 electron/preload.ts       — contextBridge API (platform + characterWindow IPC bridge)
-src/api/client.ts         — Axios + WebSocket singleton; streaming via wsManager
+src/api/client.ts         — Axios + WebSocket singleton; streaming + media via wsManager
 src/api/types.ts          — TypeScript interfaces for API
 src/components/
   LoginWindow.tsx          — Login/Register tabs, Remember Me, Server URL field, purple gradient
   MainWindow.tsx           — Permanent sidebar (280px) + ChatWidget, conversation CRUD
   ChatWidget.tsx           — Chat UI with streaming, TTS auto-play, image attach, pagination, IPC bridge to character window
   MessageBubble.tsx        — Individual bubble: role styling, thinking collapse, TTS, resend/delete
+  ToolsWindow.tsx          — Three tabs: MCP Tools, Built-in Tools, Skills (CRUD + import/export for user-editable instruction blocks)
   AgentsWindow.tsx         — Agent CRUD with tool assignment + character config button
   FacesWindow.tsx          — Face identity CRUD, webcam vision controls, live recognition display
+  MediaPlayerBar.tsx       — Bottom bar: track info, play/pause/skip/stop, volume slider, slide-up animation. Visible when media playing/buffering.
   CharacterConfigDialog.tsx — React Flow graph editor: multi-pose nodes, edges with transition videos, conditions
   PoseNodeEditor.tsx        — Extracted 3-step stepper sub-dialog for editing individual pose nodes
   EdgeEditor.tsx            — Transition edge editor: video upload, condition config (random timer)
@@ -44,6 +46,7 @@ src/store/
   conversationStore.ts    — Conversations, messages (paginated 50/page), models
   agentStore.ts           — Agent list (filtered, no Administrator), selected agent ID (persisted)
   visionStore.ts          — Zustand singleton: vision pipeline control (getUserMedia webcam capture, frame upload at 3 FPS via WebSocket, face/pose/hands toggles, WebSocket vision_result listener + gesture IPC forwarding). Used by both FacesWindow and ChatWidget camera toggle.
+  mediaStore.ts           — Zustand singleton: media player state (playback, track, queue, volume). All media events (control + chunks) flow through wsManager on /ws/chat. Module-level listeners for media_state/media_chunk/media_error. Buffers base64 chunks → Blob → Audio playback. Volume persisted to localStorage.
 src/CharacterWindowApp.tsx — Minimal IPC-driven renderer for separate character window (no auth/stores)
 src/videocall/            — Character animation engine (rendered in separate Electron window via IPC)
   types.ts                — PoseConfig, PatchInfo, PoseTree, AnimationNode/Edge/EdgeTransition, TransitionCondition (random/thinking/gesture), AnimationSettings, CharacterConfig, migrateEdgeToTransitions()
@@ -119,6 +122,7 @@ src/config.ts             — API URL config (reads dynamically from storage)
 - `GET /faces`, `POST /faces`, `GET /faces/{id}`, `DELETE /faces/{id}` — Face identity CRUD
 - `POST /faces/{id}/photos`, `DELETE /faces/{id}/photos/{photo_id}` — Face photo management
 - `GET /faces/{id}/photos/{photo_id}/image` — Serve face photo image
+- `GET /skills`, `POST /skills`, `PATCH /skills/{id}`, `DELETE /skills/{id}` — Skill CRUD (user-editable instruction blocks)
 
 ## Character Animation
 
@@ -141,7 +145,7 @@ Separate Electron window (toggleable via Face icon in top bar). Opens as indepen
 
 ## Storage Keys (localStorage)
 
-`kurisu_auth_token`, `kurisu_remember_me`, `kurisu_selected_model`, `kurisu_backend_url`, `kurisu_tts_backend`, `kurisu_tts_voice`, `kurisu_tts_language`, `kurisu_tts_auto_play`, `kurisu_tts_emo_audio`, `kurisu_tts_emo_alpha`, `kurisu_tts_use_emo_text`, `kurisu_selected_agent_id`
+`kurisu_auth_token`, `kurisu_remember_me`, `kurisu_selected_model`, `kurisu_backend_url`, `kurisu_tts_backend`, `kurisu_tts_voice`, `kurisu_tts_language`, `kurisu_tts_auto_play`, `kurisu_tts_emo_audio`, `kurisu_tts_emo_alpha`, `kurisu_tts_use_emo_text`, `kurisu_selected_agent_id`, `kurisu_media_volume`
 
 ## Security
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -23,6 +23,9 @@ import type {
   FaceIdentity,
   FaceIdentityDetail,
   AvatarCandidate,
+  Skill,
+  SkillCreate,
+  SkillUpdate,
 } from './types';
 
 class APIClient {
@@ -516,6 +519,35 @@ class APIClient {
 
   getFacePhotoUrl(identityId: number, photoId: number): string {
     return `${config.apiBaseUrl}/faces/${identityId}/photos/${photoId}/image`;
+  }
+
+  // Skill Methods
+
+  async listSkills(): Promise<Skill[]> {
+    const response = await this.client.get<Skill[]>('/skills', {
+      headers: this.getHeaders(),
+    });
+    return response.data;
+  }
+
+  async createSkill(data: SkillCreate): Promise<Skill> {
+    const response = await this.client.post<Skill>('/skills', data, {
+      headers: this.getHeaders(),
+    });
+    return response.data;
+  }
+
+  async updateSkill(id: number, data: SkillUpdate): Promise<Skill> {
+    const response = await this.client.patch<Skill>(`/skills/${id}`, data, {
+      headers: this.getHeaders(),
+    });
+    return response.data;
+  }
+
+  async deleteSkill(id: number): Promise<void> {
+    await this.client.delete(`/skills/${id}`, {
+      headers: this.getHeaders(),
+    });
   }
 }
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -22,6 +22,7 @@ import type {
   CharacterConfigDTO,
   FaceIdentity,
   FaceIdentityDetail,
+  AvatarCandidate,
 } from './types';
 
 class APIClient {
@@ -338,6 +339,27 @@ class APIClient {
     await this.client.delete(`/agents/${id}`, {
       headers: this.getHeaders(),
     });
+  }
+
+  /**
+   * Get avatar candidates detected from character pose base images
+   */
+  async getAvatarCandidates(agentId: number): Promise<AvatarCandidate[]> {
+    const response = await this.client.get<AvatarCandidate[]>(`/agents/${agentId}/avatar-candidates`, {
+      headers: this.getHeaders(),
+      timeout: 60000,
+    });
+    return response.data;
+  }
+
+  /**
+   * Set agent avatar from an existing image UUID
+   */
+  async setAgentAvatarFromUuid(agentId: number, uuid: string): Promise<Agent> {
+    const response = await this.client.post<Agent>(`/agents/${agentId}/avatar-from-uuid`, { avatar_uuid: uuid }, {
+      headers: this.getHeaders(),
+    });
+    return response.data;
   }
 
   // Tools Methods

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -169,11 +169,30 @@ export interface ToolFunction {
 export interface Tool {
   type: string;
   function: ToolFunction;
+  built_in?: boolean;
 }
 
 export interface ToolsResponse {
   mcp_tools: Tool[];
   builtin_tools: Tool[];
+}
+
+// Skill types
+export interface Skill {
+  id: number;
+  name: string;
+  instructions: string;
+  created_at: string | null;
+}
+
+export interface SkillCreate {
+  name: string;
+  instructions?: string;
+}
+
+export interface SkillUpdate {
+  name?: string;
+  instructions?: string;
 }
 
 // Avatar candidate types
@@ -224,4 +243,14 @@ export interface VisionGesture {
 export interface VisionResult {
   faces: VisionFace[];
   gestures: VisionGesture[];
+}
+
+// Media player types
+
+export interface MediaTrack {
+  title: string;
+  url: string;
+  duration: number | null;
+  thumbnail: string | null;
+  artist: string | null;
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -68,6 +68,7 @@ export interface UserProfile {
   agent_avatar_uuid?: string;
   assistant_avatar_uuid?: string; // Alias for agent_avatar_uuid
   ollama_url?: string; // Custom Ollama server URL (null/undefined = use default)
+  summary_model?: string; // Model for frame summarization (null = use chat model)
 }
 
 export interface VoicesResponse {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -40,11 +40,19 @@ export interface Conversation {
   updated_at: string;
 }
 
+export interface FrameInfo {
+  id: number;
+  summary: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
 export interface ConversationDetail {
   id: number;
   title: string;
   created_at: string;
   messages: Message[];
+  frames: Record<number, FrameInfo>;
   total_messages: number;
   offset: number;
   limit: number;
@@ -165,6 +173,14 @@ export interface Tool {
 export interface ToolsResponse {
   mcp_tools: Tool[];
   builtin_tools: Tool[];
+}
+
+// Avatar candidate types
+
+export interface AvatarCandidate {
+  uuid: string;
+  pose_id: string;
+  score: number;
 }
 
 // Face recognition types

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -17,6 +17,9 @@ export type EventType =
   | 'done'
   | 'error'
   | 'vision_result'
+  | 'media_state'
+  | 'media_chunk'
+  | 'media_error'
   | 'reconnected';
 
 // Base event interface
@@ -107,13 +110,55 @@ export interface VisionResultEvent extends BaseEvent {
   }>;
 }
 
+export interface MediaStateEvent extends BaseEvent {
+  type: 'media_state';
+  state: 'stopped' | 'playing' | 'paused';
+  current_track: {
+    title: string;
+    url: string;
+    duration: number | null;
+    thumbnail: string | null;
+    artist: string | null;
+  } | null;
+  queue: Array<{
+    title: string;
+    url: string;
+    duration: number | null;
+    thumbnail: string | null;
+    artist: string | null;
+  }>;
+  volume: number;
+}
+
+export interface MediaChunkEvent extends BaseEvent {
+  type: 'media_chunk';
+  data: string; // base64 encoded audio
+  chunk_index: number;
+  is_last: boolean;
+  format: string;
+  sample_rate: number;
+}
+
+export interface MediaErrorEvent extends BaseEvent {
+  type: 'media_error';
+  error: string;
+}
+
+export interface ReconnectedEvent extends BaseEvent {
+  type: 'reconnected';
+}
+
 export type ServerEvent =
   | StreamChunkEvent
   | AgentSwitchEvent
   | DoneEvent
   | ErrorEvent
   | ToolApprovalRequestEvent
-  | VisionResultEvent;
+  | VisionResultEvent
+  | MediaStateEvent
+  | MediaChunkEvent
+  | MediaErrorEvent
+  | ReconnectedEvent;
 
 type EventHandler<T = ServerEvent> = (event: T) => void;
 
@@ -186,8 +231,8 @@ class WebSocketManager {
 
       this.ws.onmessage = (event) => {
         try {
-          const data = JSON.parse(event.data) as ServerEvent;
-          this.dispatchEvent(data);
+          const data = JSON.parse(event.data);
+          this.dispatchEvent(data as ServerEvent);
         } catch (e) {
           console.error('[WebSocket] Failed to parse message:', e);
         }
@@ -320,6 +365,38 @@ class WebSocketManager {
     }
   }
 
+  // Media control methods
+
+  async sendMediaPlay(query: string) {
+    await this.connect();
+    this.send({ type: 'media_play', query });
+  }
+
+  async sendMediaPause() {
+    await this.connect();
+    this.send({ type: 'media_pause' });
+  }
+
+  async sendMediaResume() {
+    await this.connect();
+    this.send({ type: 'media_resume' });
+  }
+
+  async sendMediaSkip() {
+    await this.connect();
+    this.send({ type: 'media_skip' });
+  }
+
+  async sendMediaStop() {
+    await this.connect();
+    this.send({ type: 'media_stop' });
+  }
+
+  async sendMediaVolume(volume: number) {
+    await this.connect();
+    this.send({ type: 'media_volume', volume });
+  }
+
   /**
    * Register an event handler.
    */
@@ -386,7 +463,7 @@ class WebSocketManager {
               type: 'reconnected',
               event_id: '',
               timestamp: new Date().toISOString(),
-            } as BaseEvent & { type: 'reconnected' });
+            } as ReconnectedEvent);
           })
           .catch(console.error);
       }

--- a/src/components/AgentsWindow.tsx
+++ b/src/components/AgentsWindow.tsx
@@ -37,11 +37,13 @@ import {
   Settings as SettingsIcon,
   Extension as ExtensionIcon,
   Face as FaceIcon,
+  AutoAwesome as AutoAwesomeIcon,
 } from '@mui/icons-material';
+import { CircularProgress } from '@mui/material';
 import { motion, AnimatePresence } from 'framer-motion';
 import { apiClient } from '../api/client';
 import { useAgentStore } from '../store/agentStore';
-import type { Agent, AgentCreate, AgentUpdate, Tool } from '../api/types';
+import type { Agent, AgentCreate, AgentUpdate, Tool, AvatarCandidate } from '../api/types';
 import { CharacterConfigDialog } from './CharacterConfigDialog';
 
 const MotionCard = motion(Card);
@@ -90,6 +92,8 @@ export const AgentsWindow: React.FC = () => {
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [voiceFile, setVoiceFile] = useState<File | null>(null);
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
+  const [avatarCandidates, setAvatarCandidates] = useState<AvatarCandidate[]>([]);
+  const [isDetecting, setIsDetecting] = useState(false);
 
   useEffect(() => {
     loadAgents();
@@ -232,6 +236,7 @@ export const AgentsWindow: React.FC = () => {
     setAvatarFile(null);
     setVoiceFile(null);
     setAvatarPreview(null);
+    setAvatarCandidates([]);
     setSelectedAgent(null);
   };
 
@@ -652,27 +657,90 @@ export const AgentsWindow: React.FC = () => {
         <DialogContent>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, mt: 1 }}>
             {/* Avatar */}
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-              <Avatar
-                src={avatarPreview || undefined}
-                sx={{ width: 80, height: 80, bgcolor: 'primary.main', fontSize: '2rem' }}
-              >
-                {formData.name?.[0]?.toUpperCase() || 'A'}
-              </Avatar>
-              <input
-                ref={avatarInputRef}
-                type="file"
-                accept="image/*"
-                style={{ display: 'none' }}
-                onChange={handleAvatarSelect}
-              />
-              <Button
-                variant="outlined"
-                startIcon={<PhotoCameraIcon />}
-                onClick={() => avatarInputRef.current?.click()}
-              >
-                Change Avatar
-              </Button>
+            <Box>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                <Avatar
+                  src={avatarPreview || undefined}
+                  sx={{ width: 80, height: 80, bgcolor: 'primary.main', fontSize: '2rem' }}
+                >
+                  {formData.name?.[0]?.toUpperCase() || 'A'}
+                </Avatar>
+                <input
+                  ref={avatarInputRef}
+                  type="file"
+                  accept="image/*"
+                  style={{ display: 'none' }}
+                  onChange={handleAvatarSelect}
+                />
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                  <Button
+                    variant="outlined"
+                    startIcon={<PhotoCameraIcon />}
+                    onClick={() => avatarInputRef.current?.click()}
+                    size="small"
+                  >
+                    Change Avatar
+                  </Button>
+                  {selectedAgent?.character_config && (
+                    <Button
+                      variant="outlined"
+                      startIcon={isDetecting ? <CircularProgress size={16} /> : <AutoAwesomeIcon />}
+                      onClick={async () => {
+                        if (!selectedAgent) return;
+                        setIsDetecting(true);
+                        setAvatarCandidates([]);
+                        try {
+                          const candidates = await apiClient.getAvatarCandidates(selectedAgent.id);
+                          setAvatarCandidates(candidates);
+                          if (candidates.length === 0) {
+                            setError('No faces detected in pose images');
+                          }
+                        } catch (err: any) {
+                          setError(err.response?.data?.detail || 'Failed to detect faces');
+                        } finally {
+                          setIsDetecting(false);
+                        }
+                      }}
+                      disabled={isDetecting}
+                      size="small"
+                    >
+                      {isDetecting ? 'Detecting...' : 'Detect from Poses'}
+                    </Button>
+                  )}
+                </Box>
+              </Box>
+              {avatarCandidates.length > 0 && (
+                <Box sx={{ mt: 2, display: 'flex', gap: 1.5, flexWrap: 'wrap' }}>
+                  {avatarCandidates.map((candidate) => (
+                    <Tooltip key={candidate.uuid} title={`Pose: ${candidate.pose_id} (${(candidate.score * 100).toFixed(0)}%)`}>
+                      <Avatar
+                        src={apiClient.getImageUrl(candidate.uuid)}
+                        sx={{
+                          width: 64,
+                          height: 64,
+                          cursor: 'pointer',
+                          border: '2px solid transparent',
+                          '&:hover': { borderColor: 'primary.main', boxShadow: 2 },
+                          transition: 'border-color 0.2s, box-shadow 0.2s',
+                        }}
+                        onClick={async () => {
+                          if (!selectedAgent) return;
+                          try {
+                            await apiClient.setAgentAvatarFromUuid(selectedAgent.id, candidate.uuid);
+                            setAvatarPreview(apiClient.getImageUrl(candidate.uuid));
+                            setAvatarCandidates([]);
+                            setSuccessMessage('Avatar updated!');
+                            setTimeout(() => setSuccessMessage(''), 3000);
+                            loadAgents();
+                          } catch (err: any) {
+                            setError(err.response?.data?.detail || 'Failed to set avatar');
+                          }
+                        }}
+                      />
+                    </Tooltip>
+                  ))}
+                </Box>
+              )}
             </Box>
 
             {/* Name */}

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -38,6 +38,7 @@ import { useVisionStore } from '../store/visionStore';
 import type { AmplitudeState } from '../videocall/CharacterRenderer';
 import type { PoseTree } from '../videocall/types';
 import { MessageBubble } from './MessageBubble';
+import { FrameSeparator } from './FrameSeparator';
 import type { Message } from '../api/types';
 
 interface ChatWidgetProps {
@@ -48,6 +49,7 @@ interface ChatWidgetProps {
 export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = false, agentId = null }) => {
   const {
     messages,
+    frames,
     currentConversation,
     hasMoreMessages,
     isLoadingMessages,
@@ -916,21 +918,36 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
               }
               return true;
             });
-            return filtered.map((message, index, arr) => {
-              // Match by object identity to find the actual streaming message
+
+            const elements: React.ReactNode[] = [];
+            let lastFrameId: number | undefined;
+
+            filtered.forEach((message, index) => {
+              const currentFrameId = message.frame_id;
+              // Insert separator when frame changes (not before first message)
+              if (currentFrameId && currentFrameId !== lastFrameId && lastFrameId !== undefined) {
+                const frameInfo = frames[currentFrameId];
+                if (frameInfo) {
+                  elements.push(
+                    <FrameSeparator key={`frame-sep-${currentFrameId}`} frame={frameInfo} />
+                  );
+                }
+              }
+              lastFrameId = currentFrameId;
+
               const isActiveStreaming = message === activeStreamingMsg;
-              return (
+              elements.push(
                 <MessageBubble
                   key={message.id ? `msg-${message.id}` : `stream-${index}`}
                   message={message}
                   index={index}
-                  isLast={index === arr.length - 1}
+                  isLast={index === filtered.length - 1}
                   isStreaming={isActiveStreaming}
                   streamingThinking={isActiveStreaming ? streamingThinking : ''}
                   streamingContent={isActiveStreaming ? streamingContent : ''}
                   displayedThinking={isActiveStreaming ? streamingThinking : ''}
                   displayedContent={isActiveStreaming ? streamingContent : ''}
-                  justFinishedStreaming={index === arr.length - 1 && justFinishedStreaming}
+                  justFinishedStreaming={index === filtered.length - 1 && justFinishedStreaming}
                   expandedThinking={expandedThinking}
                   onToggleThinking={toggleThinking}
                   onResend={handleResend}
@@ -939,6 +956,8 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
                 />
               );
             });
+
+            return elements;
           })()}
         </AnimatePresence>
         <div ref={messagesEndRef} />

--- a/src/components/FrameSeparator.tsx
+++ b/src/components/FrameSeparator.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Box, Chip, Tooltip } from '@mui/material';
+import type { FrameInfo } from '../api/types';
+
+interface FrameSeparatorProps {
+  frame: FrameInfo;
+}
+
+export const FrameSeparator: React.FC<FrameSeparatorProps> = ({ frame }) => {
+  const dateStr = frame.created_at
+    ? new Date(frame.created_at).toLocaleString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    : 'New session';
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        my: 2,
+        gap: 1,
+      }}
+    >
+      <Box sx={{ flex: 1, height: '1px', bgcolor: 'divider' }} />
+      <Tooltip title={frame.summary || ''} placement="top" arrow disableHoverListener={!frame.summary}>
+        <Chip
+          label={dateStr}
+          size="small"
+          variant="outlined"
+          sx={{
+            fontSize: '0.7rem',
+            height: 22,
+            color: 'text.secondary',
+            borderColor: 'divider',
+          }}
+        />
+      </Tooltip>
+      <Box sx={{ flex: 1, height: '1px', bgcolor: 'divider' }} />
+    </Box>
+  );
+};

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -41,6 +41,7 @@ import { SettingsWindow } from './SettingsWindow';
 import { AgentsWindow } from './AgentsWindow';
 import { ToolsWindow } from './ToolsWindow';
 import { FacesWindow } from './FacesWindow';
+import { MediaPlayerBar } from './MediaPlayerBar';
 
 const DRAWER_WIDTH = 280;
 
@@ -325,6 +326,7 @@ export const MainWindow: React.FC = () => {
           {currentPage === 'settings' && (
             <SettingsWindow onBack={() => setCurrentPage('chat')} />
           )}
+          <MediaPlayerBar />
         </Box>
       </Box>
     </Box>

--- a/src/components/MediaPlayerBar.tsx
+++ b/src/components/MediaPlayerBar.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { Box, IconButton, Slider, Typography, CircularProgress } from '@mui/material';
+import {
+  PlayArrow as PlayIcon,
+  Pause as PauseIcon,
+  SkipNext as SkipIcon,
+  Close as CloseIcon,
+  VolumeUp as VolumeIcon,
+  MusicNote as MusicNoteIcon,
+} from '@mui/icons-material';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useMediaStore } from '../store/mediaStore';
+
+export const MediaPlayerBar: React.FC = () => {
+  const { playbackState, currentTrack, queue, volume, isBuffering, pause, resume, skip, stop, setVolume } =
+    useMediaStore();
+
+  const isVisible = playbackState !== 'stopped' || isBuffering;
+
+  return (
+    <AnimatePresence>
+      {isVisible && (
+        <motion.div
+          initial={{ y: 64, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: 64, opacity: 0 }}
+          transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              height: 64,
+              px: 2,
+              gap: 1.5,
+              backgroundColor: '#F9F9F9',
+              borderTop: '1px solid',
+              borderColor: 'divider',
+              flexShrink: 0,
+            }}
+          >
+            {/* Thumbnail */}
+            {currentTrack?.thumbnail ? (
+              <Box
+                component="img"
+                src={currentTrack.thumbnail}
+                alt=""
+                sx={{ width: 48, height: 48, borderRadius: 1, objectFit: 'cover', flexShrink: 0 }}
+              />
+            ) : (
+              <Box
+                sx={{
+                  width: 48,
+                  height: 48,
+                  borderRadius: 1,
+                  backgroundColor: 'action.hover',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  flexShrink: 0,
+                }}
+              >
+                <MusicNoteIcon color="disabled" />
+              </Box>
+            )}
+
+            {/* Track info */}
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography
+                variant="body2"
+                sx={{ fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+              >
+                {currentTrack?.title ?? 'Loading...'}
+              </Typography>
+              {currentTrack?.artist && (
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'block' }}
+                >
+                  {currentTrack.artist}
+                </Typography>
+              )}
+            </Box>
+
+            {/* Controls */}
+            {isBuffering ? (
+              <CircularProgress size={24} />
+            ) : (
+              <IconButton
+                size="small"
+                onClick={playbackState === 'playing' ? pause : resume}
+              >
+                {playbackState === 'playing' ? <PauseIcon /> : <PlayIcon />}
+              </IconButton>
+            )}
+
+            <IconButton size="small" onClick={skip} disabled={queue.length === 0 && !currentTrack}>
+              <SkipIcon />
+            </IconButton>
+
+            {/* Volume */}
+            <VolumeIcon fontSize="small" color="action" />
+            <Slider
+              size="small"
+              min={0}
+              max={1}
+              step={0.05}
+              value={volume}
+              onChange={(_, v) => setVolume(v as number)}
+              sx={{ width: 100 }}
+            />
+
+            {/* Stop / Close */}
+            <IconButton size="small" onClick={stop}>
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Box>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/components/SettingsWindow.tsx
+++ b/src/components/SettingsWindow.tsx
@@ -46,6 +46,8 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ onBack }) => {
 
   const [preferredName, setPreferredName] = useState('');
   const [ollamaUrl, setOllamaUrl] = useState('');
+  const [summaryModel, setSummaryModel] = useState('');
+  const [models, setModels] = useState<string[]>([]);
   const [userAvatarFile, setUserAvatarFile] = useState<File | null>(null);
   const [userAvatarPreview, setUserAvatarPreview] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
@@ -74,6 +76,7 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ onBack }) => {
     if (user) {
       setPreferredName(user.preferred_name || '');
       setOllamaUrl(user.ollama_url || '');
+      setSummaryModel(user.summary_model || '');
 
       if (user.user_avatar_uuid) {
         setUserAvatarPreview(apiClient.getImageUrl(user.user_avatar_uuid));
@@ -81,10 +84,11 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ onBack }) => {
     }
   }, [user]);
 
-  // Load TTS voices and backends on mount
+  // Load TTS voices, backends, and models on mount
   useEffect(() => {
     loadVoices();
     loadBackends();
+    apiClient.getModels().then(setModels).catch(() => {});
   }, [loadVoices, loadBackends]);
 
   const handleUserAvatarSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -112,6 +116,7 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ onBack }) => {
       }
       // Always include ollama_url (empty string will clear it on backend)
       profileUpdates.ollama_url = ollamaUrl || '';
+      profileUpdates.summary_model = summaryModel || '';
 
       if (Object.keys(profileUpdates).length > 0) {
         await apiClient.updateUserProfile(profileUpdates);
@@ -240,6 +245,30 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ onBack }) => {
               placeholder="http://localhost:11434"
               helperText="Leave empty to use the default server"
             />
+          </Box>
+
+          {/* Summary Model */}
+          <Box sx={{ mb: 4 }}>
+            <FormControl fullWidth>
+              <InputLabel>Summary Model</InputLabel>
+              <Select
+                value={summaryModel}
+                label="Summary Model"
+                onChange={(e) => setSummaryModel(e.target.value)}
+              >
+                <MenuItem value="">
+                  <em>Use chat model</em>
+                </MenuItem>
+                {models.map((model) => (
+                  <MenuItem key={model} value={model}>
+                    {model}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
+              Model used to generate session summaries. Leave empty to use the active chat model.
+            </Typography>
           </Box>
 
           {/* Save Account Settings Button */}

--- a/src/components/ToolsWindow.tsx
+++ b/src/components/ToolsWindow.tsx
@@ -17,6 +17,7 @@ import {
   Tab,
   Button,
   CircularProgress,
+  TextField,
 } from '@mui/material';
 import {
   Refresh as RefreshIcon,
@@ -24,10 +25,16 @@ import {
   Dns as DnsIcon,
   CheckCircle as CheckCircleIcon,
   Cancel as CancelIcon,
+  AutoFixHigh as SkillIcon,
+  Add as AddIcon,
+  Edit as EditIcon,
+  Delete as DeleteIcon,
+  FileUpload as ImportIcon,
+  FileDownload as ExportIcon,
 } from '@mui/icons-material';
 import { motion, AnimatePresence } from 'framer-motion';
 import { apiClient } from '../api/client';
-import type { MCPServer, Tool } from '../api/types';
+import type { MCPServer, Tool, Skill } from '../api/types';
 
 const MotionCard = motion(Card);
 
@@ -54,10 +61,18 @@ export const ToolsWindow: React.FC = () => {
   const [currentTab, setCurrentTab] = useState(0);
   const [mcpServers, setMcpServers] = useState<MCPServer[]>([]);
   const [tools, setTools] = useState<{ mcp: Tool[], builtin: Tool[] }>({ mcp: [], builtin: [] });
+  const [skills, setSkills] = useState<Skill[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [selectedTool, setSelectedTool] = useState<Tool | null>(null);
   const [detailsDialogOpen, setDetailsDialogOpen] = useState(false);
+
+  // Skill editor state
+  const [skillDialogOpen, setSkillDialogOpen] = useState(false);
+  const [editingSkill, setEditingSkill] = useState<Skill | null>(null);
+  const [skillName, setSkillName] = useState('');
+  const [skillInstructions, setSkillInstructions] = useState('');
+  const [skillSaving, setSkillSaving] = useState(false);
 
   useEffect(() => {
     loadData();
@@ -67,12 +82,14 @@ export const ToolsWindow: React.FC = () => {
     setLoading(true);
     setError('');
     try {
-      const [serversRes, toolsRes] = await Promise.all([
+      const [serversRes, toolsRes, skillsRes] = await Promise.all([
         apiClient.listMCPServers(),
         apiClient.listTools(),
+        apiClient.listSkills(),
       ]);
       setMcpServers(serversRes.servers);
       setTools({ mcp: toolsRes.mcp_tools, builtin: toolsRes.builtin_tools });
+      setSkills(skillsRes);
     } catch (err: any) {
       setError(err.response?.data?.detail || err.message || 'Failed to load data');
     } finally {
@@ -83,6 +100,101 @@ export const ToolsWindow: React.FC = () => {
   const handleToolClick = (tool: Tool) => {
     setSelectedTool(tool);
     setDetailsDialogOpen(true);
+  };
+
+  const handleNewSkill = () => {
+    setEditingSkill(null);
+    setSkillName('');
+    setSkillInstructions('');
+    setSkillDialogOpen(true);
+  };
+
+  const handleEditSkill = (skill: Skill) => {
+    setEditingSkill(skill);
+    setSkillName(skill.name);
+    setSkillInstructions(skill.instructions);
+    setSkillDialogOpen(true);
+  };
+
+  const handleSaveSkill = async () => {
+    if (!skillName.trim()) return;
+    setSkillSaving(true);
+    try {
+      if (editingSkill) {
+        await apiClient.updateSkill(editingSkill.id, {
+          name: skillName,
+          instructions: skillInstructions,
+        });
+      } else {
+        await apiClient.createSkill({
+          name: skillName,
+          instructions: skillInstructions,
+        });
+      }
+      setSkillDialogOpen(false);
+      // Reload skills
+      const skillsRes = await apiClient.listSkills();
+      setSkills(skillsRes);
+    } catch (err: any) {
+      setError(err.response?.data?.detail || err.message || 'Failed to save skill');
+    } finally {
+      setSkillSaving(false);
+    }
+  };
+
+  const handleDeleteSkill = async (skill: Skill) => {
+    try {
+      await apiClient.deleteSkill(skill.id);
+      setSkills(prev => prev.filter(s => s.id !== skill.id));
+    } catch (err: any) {
+      setError(err.response?.data?.detail || err.message || 'Failed to delete skill');
+    }
+  };
+
+  const handleExportSkill = (skill: Skill) => {
+    const exportData = {
+      name: skill.name,
+      instructions: skill.instructions,
+      version: 1,
+    };
+    const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${skill.name.replace(/[^a-zA-Z0-9_-]/g, '_')}.skill.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImportSkill = () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json,.skill.json';
+    input.multiple = true;
+    input.onchange = async (e) => {
+      const files = (e.target as HTMLInputElement).files;
+      if (!files) return;
+
+      for (const file of Array.from(files)) {
+        try {
+          const text = await file.text();
+          const data = JSON.parse(text);
+          if (!data.name || typeof data.name !== 'string') {
+            setError(`Invalid skill file: ${file.name} — missing "name" field`);
+            continue;
+          }
+          await apiClient.createSkill({
+            name: data.name,
+            instructions: data.instructions || '',
+          });
+        } catch (err: any) {
+          setError(err.response?.data?.detail || err.message || `Failed to import ${file.name}`);
+        }
+      }
+      const skillsRes = await apiClient.listSkills();
+      setSkills(skillsRes);
+    };
+    input.click();
   };
 
   const getStatusColor = (status: string) => {
@@ -132,6 +244,7 @@ export const ToolsWindow: React.FC = () => {
         <Tabs value={currentTab} onChange={(_, v) => setCurrentTab(v)}>
           <Tab icon={<DnsIcon />} iconPosition="start" label="MCP Servers" />
           <Tab icon={<ExtensionIcon />} iconPosition="start" label="Available Tools" />
+          <Tab icon={<SkillIcon />} iconPosition="start" label="Skills" />
         </Tabs>
       </Box>
 
@@ -298,7 +411,7 @@ export const ToolsWindow: React.FC = () => {
                               <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
                                 {tool.function.name}
                               </Typography>
-                              <Chip label="Built-in" size="small" color="secondary" variant="outlined" />
+                              {tool.built_in && <Chip label="Built-in" size="small" color="secondary" variant="outlined" />}
                             </Box>
                             <Typography
                               variant="body2"
@@ -321,6 +434,109 @@ export const ToolsWindow: React.FC = () => {
                   </AnimatePresence>
                 </Grid>
               )}
+            </TabPanel>
+
+            {/* Skills Tab */}
+            <TabPanel value={currentTab} index={2}>
+              <Box sx={{ maxWidth: 900, mx: 'auto' }}>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+                  <Box>
+                    <Typography variant="body2" color="text.secondary">
+                      Skills are instructions injected into every agent's system prompt, teaching the LLM when and how to use its capabilities.
+                    </Typography>
+                  </Box>
+                  <Box sx={{ display: 'flex', gap: 1, ml: 2, flexShrink: 0 }}>
+                    <Button
+                      variant="outlined"
+                      startIcon={<ImportIcon />}
+                      onClick={handleImportSkill}
+                    >
+                      Import
+                    </Button>
+                    <Button
+                      variant="contained"
+                      startIcon={<AddIcon />}
+                      onClick={handleNewSkill}
+                    >
+                      New Skill
+                    </Button>
+                  </Box>
+                </Box>
+
+                {skills.length === 0 ? (
+                  <Paper sx={{ p: 4, textAlign: 'center' }}>
+                    <SkillIcon sx={{ fontSize: 48, color: 'text.disabled', mb: 2 }} />
+                    <Typography variant="h6" gutterBottom>
+                      No Skills Defined
+                    </Typography>
+                    <Typography color="text.secondary" sx={{ mb: 2 }}>
+                      Create skills to teach your agents new capabilities. For example, create a "Music Player" skill
+                      with instructions on when and how to use the play_music tool.
+                    </Typography>
+                    <Button variant="outlined" startIcon={<AddIcon />} onClick={handleNewSkill}>
+                      Create Your First Skill
+                    </Button>
+                  </Paper>
+                ) : (
+                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                    <AnimatePresence>
+                      {skills.map((skill, index) => (
+                        <MotionCard
+                          key={skill.id}
+                          initial={{ opacity: 0, y: 20 }}
+                          animate={{ opacity: 1, y: 0 }}
+                          exit={{ opacity: 0, y: -20 }}
+                          transition={{ duration: 0.3, delay: index * 0.05 }}
+                          sx={{
+                            border: '1px solid',
+                            borderColor: 'divider',
+                          }}
+                        >
+                          <CardContent>
+                            <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
+                              <Box sx={{ flex: 1, mr: 2 }}>
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                                  <SkillIcon fontSize="small" color="primary" />
+                                  <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                                    {skill.name}
+                                  </Typography>
+                                </Box>
+                                <Typography
+                                  variant="body2"
+                                  color="text.secondary"
+                                  sx={{
+                                    whiteSpace: 'pre-wrap',
+                                    fontFamily: 'monospace',
+                                    fontSize: '0.8rem',
+                                    backgroundColor: '#f5f5f5',
+                                    p: 1.5,
+                                    borderRadius: 1,
+                                    maxHeight: 200,
+                                    overflow: 'auto',
+                                  }}
+                                >
+                                  {skill.instructions || '(no instructions)'}
+                                </Typography>
+                              </Box>
+                              <Box sx={{ display: 'flex', gap: 0.5, flexShrink: 0 }}>
+                                <IconButton size="small" onClick={() => handleExportSkill(skill)} title="Export">
+                                  <ExportIcon fontSize="small" />
+                                </IconButton>
+                                <IconButton size="small" onClick={() => handleEditSkill(skill)} title="Edit">
+                                  <EditIcon fontSize="small" />
+                                </IconButton>
+                                <IconButton size="small" onClick={() => handleDeleteSkill(skill)} title="Delete" color="error">
+                                  <DeleteIcon fontSize="small" />
+                                </IconButton>
+                              </Box>
+                            </Box>
+                          </CardContent>
+                        </MotionCard>
+                      ))}
+                    </AnimatePresence>
+                  </Box>
+                )}
+              </Box>
             </TabPanel>
           </>
         )}
@@ -348,7 +564,7 @@ export const ToolsWindow: React.FC = () => {
                   Source
                 </Typography>
                 <Chip
-                  label={tools.mcp.some(t => t.function.name === selectedTool.function.name) ? 'MCP' : 'Built-in'}
+                  label={tools.mcp.some(t => t.function.name === selectedTool.function.name) ? 'MCP' : selectedTool.built_in ? 'Built-in' : 'Native'}
                   color={tools.mcp.some(t => t.function.name === selectedTool.function.name) ? 'primary' : 'secondary'}
                   size="small"
                 />
@@ -390,6 +606,57 @@ export const ToolsWindow: React.FC = () => {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setDetailsDialogOpen(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Skill Editor Dialog */}
+      <Dialog
+        open={skillDialogOpen}
+        onClose={() => setSkillDialogOpen(false)}
+        maxWidth="md"
+        fullWidth
+      >
+        <DialogTitle>
+          {editingSkill ? 'Edit Skill' : 'New Skill'}
+        </DialogTitle>
+        <DialogContent dividers>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, pt: 1 }}>
+            <TextField
+              label="Skill Name"
+              value={skillName}
+              onChange={(e) => setSkillName(e.target.value)}
+              fullWidth
+              placeholder="e.g., Music Player"
+            />
+            <TextField
+              label="Instructions"
+              value={skillInstructions}
+              onChange={(e) => setSkillInstructions(e.target.value)}
+              fullWidth
+              multiline
+              minRows={6}
+              maxRows={16}
+              placeholder={
+                'Write instructions that teach the LLM how to use this capability.\n\n' +
+                'Example:\n' +
+                'You have access to a music player that can stream audio from YouTube.\n' +
+                '- When the user asks to play a song, use the `play_music` tool.\n' +
+                '- Use `music_control` to pause, resume, skip, or stop.\n' +
+                '- Use `get_music_queue` to check what\'s playing.'
+              }
+              helperText="These instructions are injected into every agent's system prompt."
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setSkillDialogOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={handleSaveSkill}
+            disabled={!skillName.trim() || skillSaving}
+          >
+            {skillSaving ? <CircularProgress size={20} /> : 'Save'}
+          </Button>
         </DialogActions>
       </Dialog>
     </Box>

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -1,11 +1,12 @@
 import { create } from 'zustand';
 import { apiClient } from '../api/client';
-import type { Conversation, Message } from '../api/types';
+import type { Conversation, FrameInfo, Message } from '../api/types';
 
 interface ConversationState {
   conversations: Conversation[];
   currentConversation: Conversation | null;
   messages: Message[];
+  frames: Record<number, FrameInfo>;
 
   // Pagination state
   totalMessages: number;
@@ -27,6 +28,7 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
   conversations: [],
   currentConversation: null,
   messages: [],
+  frames: {},
 
   // Pagination state initialization
   totalMessages: 0,
@@ -47,6 +49,7 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
     set({
       currentConversation: conversation,
       messages: data.messages,
+      frames: data.frames || {},
       totalMessages: data.total_messages,
       hasMoreMessages: data.has_more,
       messagesOffset: data.limit, // Next offset for loading more
@@ -71,9 +74,10 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
         messagesOffset
       );
 
-      // Prepend older messages to the beginning
+      // Prepend older messages to the beginning, merge frames
       set((state) => ({
         messages: [...data.messages, ...state.messages],
+        frames: { ...state.frames, ...(data.frames || {}) },
         hasMoreMessages: data.has_more,
         messagesOffset: state.messagesOffset + data.messages.length,
         isLoadingMessages: false,
@@ -87,13 +91,14 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
   deleteConversation: async (id: number) => {
     await apiClient.deleteConversation(id);
     const conversations = get().conversations.filter((c) => c.id !== id);
-    set({ conversations, currentConversation: null, messages: [] });
+    set({ conversations, currentConversation: null, messages: [], frames: {} });
   },
 
   createNewConversation: () => {
     set({
       currentConversation: null,
       messages: [],
+      frames: {},
       totalMessages: 0,
       hasMoreMessages: false,
       messagesOffset: 0,

--- a/src/store/mediaStore.ts
+++ b/src/store/mediaStore.ts
@@ -1,0 +1,196 @@
+import { create } from 'zustand';
+import { wsManager, MediaStateEvent, MediaChunkEvent, MediaErrorEvent } from '../api/websocket';
+import type { MediaTrack } from '../api/types';
+
+const VOLUME_STORAGE_KEY = 'kurisu_media_volume';
+
+interface MediaState {
+  playbackState: 'stopped' | 'playing' | 'paused';
+  currentTrack: MediaTrack | null;
+  queue: MediaTrack[];
+  volume: number;
+  isBuffering: boolean;
+  error: string | null;
+
+  play: (query: string) => void;
+  pause: () => void;
+  resume: () => void;
+  skip: () => void;
+  stop: () => void;
+  setVolume: (v: number) => void;
+  clearError: () => void;
+}
+
+// Module-level audio state (not in Zustand to avoid re-renders on chunk accumulation)
+let _chunks: string[] = [];
+let _chunkFormat: string = 'webm';
+let _audio: HTMLAudioElement | null = null;
+let _audioUrl: string | null = null;
+
+function _cleanupAudio() {
+  if (_audio) {
+    _audio.pause();
+    _audio.src = '';
+    _audio = null;
+  }
+  if (_audioUrl) {
+    URL.revokeObjectURL(_audioUrl);
+    _audioUrl = null;
+  }
+}
+
+function _base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+function _playBuffer() {
+  // Concatenate all chunks into a single ArrayBuffer
+  const buffers = _chunks.map(_base64ToArrayBuffer);
+  const totalLength = buffers.reduce((sum, buf) => sum + buf.byteLength, 0);
+  const combined = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const buf of buffers) {
+    combined.set(new Uint8Array(buf), offset);
+    offset += buf.byteLength;
+  }
+
+  _cleanupAudio();
+
+  const mimeType = _chunkFormat === 'webm' ? 'audio/webm; codecs=opus'
+    : _chunkFormat === 'm4a' ? 'audio/mp4'
+    : `audio/${_chunkFormat}`;
+  console.log(`[media] Playing buffer: ${_chunks.length} chunks, ${totalLength} bytes, format=${_chunkFormat}, mime=${mimeType}`);
+  const blob = new Blob([combined], { type: mimeType });
+  _audioUrl = URL.createObjectURL(blob);
+  _audio = new Audio(_audioUrl);
+  _audio.volume = useMediaStore.getState().volume;
+
+  _audio.onended = () => {
+    _cleanupAudio();
+    useMediaStore.setState({ playbackState: 'stopped', currentTrack: null, isBuffering: false });
+  };
+
+  _audio.onerror = () => {
+    const err = _audio?.error;
+    const msg = err ? `code=${err.code} ${err.message}` : 'unknown';
+    console.error(`[media] Audio element error: ${msg}`);
+    useMediaStore.setState({ error: `Playback failed: ${msg}`, isBuffering: false });
+  };
+
+  _audio.play().catch((err) => {
+    console.error('[media] Audio.play() rejected:', err);
+    useMediaStore.setState({ error: `Playback failed: ${err.message}`, isBuffering: false });
+  });
+
+  _chunks = [];
+  useMediaStore.setState({ isBuffering: false });
+}
+
+export const useMediaStore = create<MediaState>((set) => ({
+  playbackState: 'stopped',
+  currentTrack: null,
+  queue: [],
+  volume: (() => {
+    const saved = localStorage.getItem(VOLUME_STORAGE_KEY);
+    return saved !== null ? parseFloat(saved) : 1.0;
+  })(),
+  isBuffering: false,
+  error: null,
+
+  play: (query: string) => {
+    wsManager.sendMediaPlay(query);
+  },
+
+  pause: () => {
+    if (_audio) {
+      _audio.pause();
+      set({ playbackState: 'paused' });
+    }
+  },
+
+  resume: () => {
+    if (_audio) {
+      _audio.play();
+      set({ playbackState: 'playing' });
+    }
+  },
+
+  skip: () => {
+    _cleanupAudio();
+    _chunks = [];
+    wsManager.sendMediaSkip();
+  },
+
+  stop: () => {
+    _cleanupAudio();
+    _chunks = [];
+    wsManager.sendMediaStop();
+    set({ playbackState: 'stopped', currentTrack: null, queue: [], isBuffering: false });
+  },
+
+  setVolume: (v: number) => {
+    set({ volume: v });
+    localStorage.setItem(VOLUME_STORAGE_KEY, String(v));
+    if (_audio) _audio.volume = v;
+    wsManager.sendMediaVolume(v);
+  },
+
+  clearError: () => set({ error: null }),
+}));
+
+// Module-level WebSocket listeners — singleton, runs for app lifetime
+wsManager.on<MediaStateEvent>('media_state', (event) => {
+  console.log(`[media] media_state received: state=${event.state}, track=${event.current_track?.title ?? 'none'}`);
+
+  // Ignore backend 'stopped' if client-side is still buffering or playing
+  if (event.state === 'stopped' && (_audio || _chunks.length > 0 || useMediaStore.getState().isBuffering)) {
+    return;
+  }
+
+  const update: Partial<MediaState> = {
+    playbackState: event.state,
+    currentTrack: event.current_track,
+    queue: event.queue,
+  };
+
+  // When a new track starts playing, prepare to buffer chunks
+  const currentTrack = useMediaStore.getState().currentTrack;
+  const isNewTrack = event.current_track?.url !== currentTrack?.url;
+  if (event.state === 'playing' && isNewTrack) {
+    _chunks = [];
+    update.isBuffering = true;
+  }
+
+  useMediaStore.setState(update);
+});
+
+wsManager.on<MediaChunkEvent>('media_chunk', (event) => {
+  _chunks.push(event.data);
+  _chunkFormat = event.format;
+
+  // Show player bar as soon as first chunk arrives (don't wait for media_state)
+  if (event.chunk_index === 0) {
+    console.log(`[media] First chunk received, format=${event.format}`);
+    const state = useMediaStore.getState();
+    if (state.playbackState === 'stopped') {
+      useMediaStore.setState({ playbackState: 'playing', isBuffering: true });
+    }
+  }
+  if (event.chunk_index > 0 && event.chunk_index % 50 === 0) {
+    console.log(`[media] ${event.chunk_index} chunks received so far`);
+  }
+  if (event.is_last) {
+    console.log(`[media] Last chunk received, total=${_chunks.length} chunks`);
+    _playBuffer();
+  }
+});
+
+wsManager.on<MediaErrorEvent>('media_error', (event) => {
+  console.log(`[media] media_error received: ${event.error}`);
+  useMediaStore.setState({ error: event.error, isBuffering: false });
+});


### PR DESCRIPTION
## Summary
- **MediaPlayerBar**: Bottom bar with track info, play/pause/skip/stop, volume slider. Buffers base64 WebSocket chunks into Blob → HTMLAudioElement playback. Client-side pause/resume (no backend round-trip).
- **Skills tab**: CRUD UI in ToolsWindow with import/export for user-editable instruction blocks.
- **FrameSeparator**: Visual date chip between conversation frames with summary tooltip.
- **WebSocket**: Media events (media_state, media_chunk, media_error) flow through single `/ws/chat` connection.

## Test plan
- [ ] Play music via LLM — MediaPlayerBar appears, audio plays
- [ ] Pause/resume/skip/stop controls work
- [ ] Volume slider persists across sessions
- [ ] Player bar disappears when audio finishes
- [ ] Skills CRUD: create, edit, delete, import, export
- [ ] Frame separators show between conversation frames

🤖 Generated with [Claude Code](https://claude.com/claude-code)