### PR TITLE
Add agent memory field and fix summary model selector

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -100,6 +100,7 @@ export interface Agent {
   tools: string[] | null;
   think: boolean;
   character_config: CharacterConfigDTO | null;
+  memory: string | null;
 }
 
 // Character asset types (backend responses)
@@ -145,6 +146,7 @@ export interface AgentUpdate {
   model_name?: string;
   tools?: string[];
   think?: boolean;
+  memory?: string;
 }
 
 // MCP Server types

--- a/src/components/AgentsWindow.tsx
+++ b/src/components/AgentsWindow.tsx
@@ -57,6 +57,7 @@ interface AgentFormData {
   model_name: string;
   think: boolean;
   tools: string[];
+  memory: string;
 }
 
 export const AgentsWindow: React.FC = () => {
@@ -84,6 +85,7 @@ export const AgentsWindow: React.FC = () => {
     model_name: '',
     think: false,
     tools: [],
+    memory: '',
   });
 
   // File upload refs
@@ -182,6 +184,7 @@ export const AgentsWindow: React.FC = () => {
         model_name: formData.model_name !== selectedAgent.model_name ? formData.model_name : undefined,
         think: formData.think !== selectedAgent.think ? formData.think : undefined,
         tools: toolsChanged ? formData.tools : undefined,
+        memory: formData.memory !== (selectedAgent.memory || '') ? formData.memory : undefined,
       };
 
       // Only send fields that changed
@@ -232,6 +235,7 @@ export const AgentsWindow: React.FC = () => {
       model_name: '',
       think: false,
       tools: [],
+      memory: '',
     });
     setAvatarFile(null);
     setVoiceFile(null);
@@ -248,6 +252,7 @@ export const AgentsWindow: React.FC = () => {
       model_name: agent.model_name || '',
       think: agent.think,
       tools: agent.tools || [],
+      memory: agent.memory || '',
     });
     if (agent.avatar_uuid) {
       setAvatarPreview(apiClient.getImageUrl(agent.avatar_uuid));
@@ -837,6 +842,19 @@ export const AgentsWindow: React.FC = () => {
               renderInput={(params) => (
                 <TextField {...params} label="Tools" placeholder="Select tools..." helperText="Tools this agent can use" />
               )}
+            />
+
+            {/* Agent Memory */}
+            <TextField
+              label="Memory"
+              value={formData.memory}
+              onChange={(e) => setFormData({ ...formData, memory: e.target.value })}
+              multiline
+              minRows={3}
+              maxRows={10}
+              fullWidth
+              placeholder="No memories yet. Memory is automatically built from conversations."
+              helperText="Auto-updated after conversations. You can also edit manually."
             />
 
             {/* Voice Reference */}

--- a/src/components/SettingsWindow.tsx
+++ b/src/components/SettingsWindow.tsx
@@ -256,9 +256,6 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ onBack }) => {
                 label="Summary Model"
                 onChange={(e) => setSummaryModel(e.target.value)}
               >
-                <MenuItem value="">
-                  <em>Use chat model</em>
-                </MenuItem>
                 {models.map((model) => (
                   <MenuItem key={model} value={model}>
                     {model}
@@ -267,7 +264,7 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ onBack }) => {
               </Select>
             </FormControl>
             <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
-              Model used to generate session summaries. Leave empty to use the active chat model.
+              Model used for session summaries and agent memory consolidation. Summaries are disabled until a model is selected.
             </Typography>
           </Box>
 


### PR DESCRIPTION
## Summary
- Add memory textarea to agent edit dialog for viewing/editing agent memory
- Add `memory` field to `Agent` type and `AgentUpdate` interface
- Remove "Use chat model" fallback option from summary model dropdown — require explicit model selection for frame summaries and agent memory consolidation to work

## Test plan
- [ ] Edit agent dialog shows Memory textarea with current memory content
- [ ] Editing memory and saving persists the change
- [ ] Settings > Summary Model dropdown has no empty "Use chat model" option
- [ ] Helper text reads "Summaries are disabled until a model is selected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)