### PR TITLE
Simplify conversations: one per agent, remove sidebar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ src/api/client.ts         — Axios + WebSocket singleton; streaming + media via
 src/api/types.ts          — TypeScript interfaces for API
 src/components/
   LoginWindow.tsx          — Login/Register tabs, Remember Me, Server URL field, purple gradient
-  MainWindow.tsx           — Permanent sidebar (280px) + ChatWidget, conversation CRUD
+  MainWindow.tsx           — Top bar (tabs + agent selector + clear conversation) + ChatWidget, no sidebar
   ChatWidget.tsx           — Chat UI with streaming, TTS auto-play, image attach, pagination, IPC bridge to character window
   MessageBubble.tsx        — Individual bubble: role styling, thinking collapse, TTS, resend/delete
   ToolsWindow.tsx          — Three tabs: MCP Servers, Available Tools, Skills (CRUD + import/export)
@@ -44,8 +44,8 @@ src/hooks/
   useAudioAmplitude.ts    — Web Audio API amplitude for lip sync (AudioBufferSourceNode + time-domain RMS)
 src/store/
   authStore.ts            — Auth state, login/register/logout, token persistence
-  conversationStore.ts    — Conversations, messages (paginated 50/page), models
-  agentStore.ts           — Agent list (filtered, no Administrator), selected agent ID (persisted)
+  conversationStore.ts    — Current conversation + messages (paginated 20/page). No conversation list — agent selection drives conversation via localStorage mapping.
+  agentStore.ts           — Agent list (filtered, no Administrator), selected agent ID (persisted). Agent selection triggers conversation load via agent-conversation mapping.
   visionStore.ts          — Zustand singleton: vision pipeline control (getUserMedia webcam capture, frame upload at 3 FPS via WebSocket, face/pose/hands toggles, WebSocket vision_result listener + gesture IPC forwarding). Used by both FacesWindow and ChatWidget camera toggle.
   mediaStore.ts           — Zustand singleton: media player state (playback, track, queue, volume). All media events (control + chunks) flow through wsManager on /ws/chat. Module-level listeners for media_state/media_chunk/media_error. Buffers base64 chunks → Blob → Audio playback. Volume persisted to localStorage.
 src/CharacterWindowApp.tsx — Minimal IPC-driven renderer for separate character window (no auth/stores)
@@ -55,7 +55,7 @@ src/videocall/            — Character animation engine (rendered in separate E
   engine/
     CanvasCompositor.ts   — 60fps render: blink + breathing + mouth + pose tree state machine (idle→transitioning→idle), edge timers, video transitions, configurable AnimationSettings
     ImageCache.ts         — URL→HTMLImageElement cache
-src/utils/storage.ts      — localStorage wrapper (auth token, model, TTS settings)
+src/utils/storage.ts      — localStorage wrapper (auth token, model, TTS settings, agent-conversation mapping)
 src/theme/theme.ts        — MUI theme: primary #10A37F, 8px/12px border-radius
 src/config.ts             — API URL config (reads dynamically from storage)
 ```
@@ -88,9 +88,12 @@ src/config.ts             — API URL config (reads dynamically from storage)
 - Tool messages excluded; voice reference tracked per-agent
 - Action narration (`*walks over*`) stripped via `stripNarration()` before TTS — preserves `**bold**`
 
-### Conversation Creation
-- NOT explicit POST. Backend auto-creates on first `chatStream()` with `conversationId=null`
-- First event returns `conversation_id`; `setCurrentConversationId()` refreshes sidebar if new
+### Conversation Management (One Per Agent)
+- No conversation sidebar — each agent has one conversation, managed via `kurisu_agent_conversations` localStorage mapping (`Record<string, number>`, agent ID → conversation ID)
+- Agent selection triggers conversation load (or empty state if no mapping exists)
+- Backend auto-creates conversation on first message with `conversationId=null`; first `StreamChunkEvent` saves the mapping
+- "Clear conversation" button deletes via API + removes mapping entry
+- Mapping cleared on logout (`clearAllAgentConversations`) and agent delete (`clearAgentConversationId`)
 
 ### Auth Flow
 - Login → POST /login → JWT token → stored in apiClient + localStorage (if rememberMe)
@@ -147,7 +150,7 @@ Separate Electron window (toggleable via Face icon in top bar). Opens as indepen
 
 ## Storage Keys (localStorage)
 
-`kurisu_auth_token`, `kurisu_remember_me`, `kurisu_selected_model`, `kurisu_backend_url`, `kurisu_tts_backend`, `kurisu_tts_voice`, `kurisu_tts_language`, `kurisu_tts_auto_play`, `kurisu_tts_emo_audio`, `kurisu_tts_emo_alpha`, `kurisu_tts_use_emo_text`, `kurisu_selected_agent_id`, `kurisu_media_volume`
+`kurisu_auth_token`, `kurisu_remember_me`, `kurisu_selected_model`, `kurisu_backend_url`, `kurisu_tts_backend`, `kurisu_tts_voice`, `kurisu_tts_language`, `kurisu_tts_auto_play`, `kurisu_tts_emo_audio`, `kurisu_tts_emo_alpha`, `kurisu_tts_use_emo_text`, `kurisu_selected_agent_id`, `kurisu_agent_conversations`, `kurisu_media_volume`
 
 ## Security
 

--- a/src/components/AgentsWindow.tsx
+++ b/src/components/AgentsWindow.tsx
@@ -43,6 +43,7 @@ import { CircularProgress } from '@mui/material';
 import { motion, AnimatePresence } from 'framer-motion';
 import { apiClient } from '../api/client';
 import { useAgentStore } from '../store/agentStore';
+import { storage } from '../utils/storage';
 import type { Agent, AgentCreate, AgentUpdate, Tool, AvatarCandidate } from '../api/types';
 import { CharacterConfigDialog } from './CharacterConfigDialog';
 
@@ -218,6 +219,7 @@ export const AgentsWindow: React.FC = () => {
 
     try {
       await apiClient.deleteAgent(selectedAgent.id);
+      storage.clearAgentConversationId(selectedAgent.id);
       setSuccessMessage(`Agent "${selectedAgent.name}" deleted successfully!`);
       setTimeout(() => setSuccessMessage(''), 3000);
       setDeleteDialogOpen(false);

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -375,12 +375,19 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     if (event.conversation_id && !state.conversationId) {
       state.conversationId = event.conversation_id;
       setActiveConversationId(event.conversation_id);
-      setCurrentConversationId(event.conversation_id).catch(console.error);
+      setCurrentConversationId(event.conversation_id);
+
+      // Save agent-conversation mapping
+      if (agentId) {
+        storage.setAgentConversationId(agentId, event.conversation_id);
+      } else {
+        storage.setAgentConversationId('group', event.conversation_id);
+      }
     }
 
     const messageRole = event.role;
     const agentName = event.name || undefined;
-    const agentId = event.agent_id ?? undefined;
+    const eventAgentId = event.agent_id ?? undefined;
 
     // Check if we need to create a new bubble:
     // - Role changed (user -> assistant -> tool)
@@ -416,14 +423,14 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
           role: messageRole,
           content: '',
           name: agentName,
-          agent_id: agentId,
+          agent_id: eventAgentId,
           voice_reference: event.voice_reference || undefined,
         });
         return updated;
       });
 
       state.currentRole = messageRole;
-      state.currentAgentId = agentId;
+      state.currentAgentId = eventAgentId;
       state.currentAgentName = agentName;
       state.accumulatedContent = event.content || '';
       state.accumulatedThinking = '';
@@ -432,20 +439,20 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
       ttsVoiceRef.current = event.voice_reference || undefined;
 
       // Update character panel with active agent
-      pushAgentCharacterConfig(agentId, agentName);
+      pushAgentCharacterConfig(eventAgentId, agentName);
 
       scheduleStreamUpdate(state.accumulatedContent, state.accumulatedThinking);
     } else if (!state.hasStarted) {
       // First message chunk - update placeholder bubble
       state.hasStarted = true;
       state.currentRole = messageRole;
-      state.currentAgentId = agentId;
+      state.currentAgentId = eventAgentId;
       state.currentAgentName = agentName;
       state.accumulatedContent = event.content || '';
       state.accumulatedThinking = '';
 
       // Update character panel with active agent
-      pushAgentCharacterConfig(agentId, agentName);
+      pushAgentCharacterConfig(eventAgentId, agentName);
 
       if (state.hasPlaceholder) {
         // Update placeholder with actual role/agent info
@@ -456,7 +463,7 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
               ...updated[updated.length - 1],
               role: messageRole,
               name: agentName,
-              agent_id: agentId,
+              agent_id: eventAgentId,
               voice_reference: event.voice_reference || undefined,
             };
           }
@@ -468,7 +475,7 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
           role: messageRole,
           content: '',
           name: agentName,
-          agent_id: agentId,
+          agent_id: eventAgentId,
           voice_reference: event.voice_reference || undefined,
         }]);
       }

--- a/src/components/MainWindow.tsx
+++ b/src/components/MainWindow.tsx
@@ -1,14 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import {
   Box,
-  Drawer,
-  List,
-  ListItemButton,
-  ListItemText,
-  Button,
   Typography,
   IconButton,
-  Divider,
   Alert,
   Tabs,
   Tab,
@@ -17,11 +11,8 @@ import {
   Select,
   MenuItem,
   Tooltip,
-  ToggleButtonGroup,
-  ToggleButton,
 } from '@mui/material';
 import {
-  Add as AddIcon,
   Delete as DeleteIcon,
   Logout as LogoutIcon,
   Settings as SettingsIcon,
@@ -29,23 +20,17 @@ import {
   Extension as ToolsIcon,
   Chat as ChatIcon,
   Face as FaceIcon,
-  Person as PersonIcon,
-  Groups as GroupsIcon,
 } from '@mui/icons-material';
-import { motion, AnimatePresence } from 'framer-motion';
 import { useAuthStore } from '../store/authStore';
 import { useConversationStore } from '../store/conversationStore';
 import { useAgentStore } from '../store/agentStore';
+import { storage } from '../utils/storage';
 import { ChatWidget } from './ChatWidget';
 import { SettingsWindow } from './SettingsWindow';
 import { AgentsWindow } from './AgentsWindow';
 import { ToolsWindow } from './ToolsWindow';
 import { FacesWindow } from './FacesWindow';
 import { MediaPlayerBar } from './MediaPlayerBar';
-
-const DRAWER_WIDTH = 280;
-
-const MotionListItemButton = motion(ListItemButton);
 
 type Page = 'chat' | 'settings' | 'agents' | 'tools' | 'faces';
 
@@ -55,12 +40,8 @@ const PAGE_TO_TAB: Record<string, number> = { chat: 0, agents: 1, tools: 2, face
 export const MainWindow: React.FC = () => {
   const { user, logout } = useAuthStore();
   const {
-    conversations,
     currentConversation,
-    loadConversations,
-    loadConversation,
     deleteConversation,
-    createNewConversation,
   } = useConversationStore();
   const { agents, selectedAgentId, loadAgents, selectAgent } = useAgentStore();
 
@@ -88,42 +69,25 @@ export const MainWindow: React.FC = () => {
     }
   };
 
-  const [selectedId, setSelectedId] = useState<number | null>(null);
   const [error, setError] = useState('');
   const [currentPage, setCurrentPage] = useState<Page>('chat');
 
   useEffect(() => {
-    loadConversations().catch((err) => {
-      setError('Failed to load conversations');
-      console.error(err);
-    });
     loadAgents();
-  }, [loadConversations, loadAgents]);
+  }, [loadAgents]);
 
-  const handleSelectConversation = async (id: number) => {
+  const handleClearConversation = async () => {
+    if (!currentConversation) return;
     try {
-      setSelectedId(id);
-      await loadConversation(id);
-    } catch (err: any) {
-      setError('Failed to load conversation');
-      console.error(err);
-    }
-  };
-
-  const handleNewConversation = () => {
-    setSelectedId(null);
-    createNewConversation();
-  };
-
-  const handleDelete = async () => {
-    if (selectedId !== null) {
-      try {
-        await deleteConversation(selectedId);
-        setSelectedId(null);
-      } catch (err: any) {
-        setError('Failed to delete conversation');
-        console.error(err);
+      await deleteConversation(currentConversation.id);
+      if (selectedAgentId !== null) {
+        storage.clearAgentConversationId(selectedAgentId);
+      } else {
+        storage.clearAgentConversationId('group');
       }
+    } catch (err: any) {
+      setError('Failed to delete conversation');
+      console.error(err);
     }
   };
 
@@ -158,6 +122,39 @@ export const MainWindow: React.FC = () => {
           <Tab icon={<ToolsIcon fontSize="small" />} label="Tools" iconPosition="start" />
           <Tab icon={<FaceIcon fontSize="small" />} label="Faces" iconPosition="start" />
         </Tabs>
+
+        {/* Agent selector + clear conversation */}
+        {currentPage === 'chat' && agents.length > 0 && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, ml: 2 }}>
+            <FormControl size="small" sx={{ minWidth: 160 }}>
+              <InputLabel>Agent</InputLabel>
+              <Select
+                value={selectedAgentId ?? ''}
+                label="Agent"
+                onChange={(e) => selectAgent(e.target.value as number)}
+              >
+                {agents.map((agent) => (
+                  <MenuItem key={agent.id} value={agent.id}>
+                    {agent.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <Tooltip title="Clear conversation">
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={handleClearConversation}
+                  disabled={!currentConversation}
+                  color="error"
+                >
+                  <DeleteIcon fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+          </Box>
+        )}
+
         <Box sx={{ flex: 1 }} />
         <Typography variant="body2" color="text.secondary" sx={{ mr: 1 }}>
           {user?.username}
@@ -185,125 +182,6 @@ export const MainWindow: React.FC = () => {
 
       {/* Content area */}
       <Box sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
-        {/* Sidebar - only visible on Chat tab */}
-        {currentPage === 'chat' && (
-          <Drawer
-            variant="permanent"
-            sx={{
-              width: DRAWER_WIDTH,
-              flexShrink: 0,
-              '& .MuiDrawer-paper': {
-                width: DRAWER_WIDTH,
-                boxSizing: 'border-box',
-                backgroundColor: '#F9F9F9',
-                borderRight: '1px solid #E5E5E5',
-                position: 'relative',
-              },
-            }}
-          >
-            <Box sx={{ p: 2 }}>
-              {/* Action buttons */}
-              <Box sx={{ display: 'flex', gap: 1 }}>
-                <Button
-                  fullWidth
-                  variant="contained"
-                  startIcon={<AddIcon />}
-                  onClick={handleNewConversation}
-                >
-                  New
-                </Button>
-                <IconButton
-                  color="error"
-                  onClick={handleDelete}
-                  disabled={selectedId === null}
-                  sx={{ border: '1px solid', borderColor: 'divider' }}
-                >
-                  <DeleteIcon />
-                </IconButton>
-              </Box>
-
-              {/* Mode selector */}
-              <ToggleButtonGroup
-                value="single"
-                exclusive
-                fullWidth
-                size="small"
-                sx={{ mt: 1.5 }}
-              >
-                <ToggleButton
-                  value="single"
-                  sx={{ textTransform: 'none', fontSize: '0.75rem', py: 0.5 }}
-                >
-                  <PersonIcon sx={{ fontSize: 16, mr: 0.5 }} />
-                  Single Agent
-                </ToggleButton>
-                <Tooltip title="Group discussion mode coming soon">
-                  <span style={{ flex: 1, display: 'flex' }}>
-                    <ToggleButton
-                      value="group"
-                      disabled
-                      sx={{ textTransform: 'none', fontSize: '0.75rem', py: 0.5, flex: 1 }}
-                    >
-                      <GroupsIcon sx={{ fontSize: 16, mr: 0.5 }} />
-                      Group
-                    </ToggleButton>
-                  </span>
-                </Tooltip>
-              </ToggleButtonGroup>
-
-              {/* Agent selector */}
-              {agents.length > 0 && (
-                <FormControl fullWidth size="small" sx={{ mt: 1.5 }}>
-                  <InputLabel>Agent</InputLabel>
-                  <Select
-                    value={selectedAgentId ?? ''}
-                    label="Agent"
-                    onChange={(e) => selectAgent(e.target.value as number)}
-                  >
-                    {agents.map((agent) => (
-                      <MenuItem key={agent.id} value={agent.id}>
-                        {agent.name}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              )}
-            </Box>
-
-            <Divider />
-
-            <Typography
-              variant="caption"
-              sx={{ px: 2, py: 1, color: 'text.secondary', fontWeight: 600 }}
-            >
-              CONVERSATIONS
-            </Typography>
-
-            <List sx={{ px: 1, flex: 1, overflow: 'auto' }}>
-              <AnimatePresence>
-                {conversations.map((conv) => (
-                  <MotionListItemButton
-                    key={conv.id}
-                    selected={selectedId === conv.id}
-                    onClick={() => handleSelectConversation(conv.id)}
-                    initial={{ opacity: 0, x: -20 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    exit={{ opacity: 0, x: -20 }}
-                    transition={{ duration: 0.2 }}
-                  >
-                    <ListItemText
-                      primary={conv.title}
-                      secondary={`${conv.frame_count} frames`}
-                      primaryTypographyProps={{ fontSize: '0.875rem' }}
-                      secondaryTypographyProps={{ fontSize: '0.75rem' }}
-                    />
-                  </MotionListItemButton>
-                ))}
-              </AnimatePresence>
-            </List>
-          </Drawer>
-        )}
-
         {/* Main content */}
         <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           {error && (

--- a/src/store/agentStore.ts
+++ b/src/store/agentStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { apiClient } from '../api/client';
 import { storage } from '../utils/storage';
+import { useConversationStore } from './conversationStore';
 import type { Agent } from '../api/types';
 
 const ADMINISTRATOR_NAME = 'Administrator';
@@ -29,10 +30,27 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       // Auto-select first agent if stored selection is invalid
       const { selectedAgentId } = get();
       const stillValid = selectedAgentId !== null && agents.some((a) => a.id === selectedAgentId);
-      if (!stillValid && agents.length > 0) {
-        const firstId = agents[0].id;
-        set({ selectedAgentId: firstId });
-        storage.setSelectedAgentId(firstId);
+      const finalId = stillValid ? selectedAgentId : (agents.length > 0 ? agents[0].id : null);
+
+      if (!stillValid && finalId !== null) {
+        set({ selectedAgentId: finalId });
+        storage.setSelectedAgentId(finalId);
+      }
+
+      // Load conversation for the selected agent
+      if (finalId !== null) {
+        const convStore = useConversationStore.getState();
+        const convId = storage.getAgentConversationId(finalId);
+        if (convId) {
+          try {
+            await convStore.loadConversation(convId);
+          } catch {
+            storage.clearAgentConversationId(finalId);
+            convStore.clearCurrentConversation();
+          }
+        } else {
+          convStore.clearCurrentConversation();
+        }
       }
     } catch (err) {
       console.error('Failed to load agents:', err);
@@ -47,6 +65,22 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       storage.setSelectedAgentId(id);
     } else {
       storage.clearSelectedAgentId();
+    }
+
+    // Load the conversation for this agent
+    const convStore = useConversationStore.getState();
+    if (id !== null) {
+      const convId = storage.getAgentConversationId(id);
+      if (convId) {
+        convStore.loadConversation(convId).catch(() => {
+          storage.clearAgentConversationId(id);
+          convStore.clearCurrentConversation();
+        });
+      } else {
+        convStore.clearCurrentConversation();
+      }
+    } else {
+      convStore.clearCurrentConversation();
     }
   },
 }));

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -56,6 +56,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     apiClient.clearToken();
     storage.clearToken();
     storage.setRememberMe(false);
+    storage.clearAllAgentConversations();
     set({ isAuthenticated: false, user: null, rememberMe: false });
   },
 

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -3,7 +3,6 @@ import { apiClient } from '../api/client';
 import type { Conversation, FrameInfo, Message } from '../api/types';
 
 interface ConversationState {
-  conversations: Conversation[];
   currentConversation: Conversation | null;
   messages: Message[];
   frames: Record<number, FrameInfo>;
@@ -14,18 +13,16 @@ interface ConversationState {
   messagesOffset: number;
   isLoadingMessages: boolean;
 
-  loadConversations: () => Promise<void>;
   loadConversation: (id: number) => Promise<void>;
   loadMoreMessages: () => Promise<void>;
   deleteConversation: (id: number) => Promise<void>;
-  createNewConversation: () => void;
+  clearCurrentConversation: () => void;
   addMessage: (message: Message) => void;
   updateLastMessage: (content: string, thinking?: string, role?: string, name?: string) => void;
-  setCurrentConversationId: (id: number) => Promise<void>;
+  setCurrentConversationId: (id: number) => void;
 }
 
 export const useConversationStore = create<ConversationState>((set, get) => ({
-  conversations: [],
   currentConversation: null,
   messages: [],
   frames: {},
@@ -36,23 +33,16 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
   messagesOffset: 0,
   isLoadingMessages: false,
 
-  loadConversations: async () => {
-    const conversations = await apiClient.getConversations();
-    set({ conversations });
-  },
-
   loadConversation: async (id: number) => {
-    // Load the most recent page of messages (offset=0)
     const data = await apiClient.getConversation(id, 20, 0);
-    const conversation = get().conversations.find((c) => c.id === id) || null;
 
     set({
-      currentConversation: conversation,
+      currentConversation: { id, title: data.title, frame_count: 0, created_at: data.created_at, updated_at: '' },
       messages: data.messages,
       frames: data.frames || {},
       totalMessages: data.total_messages,
       hasMoreMessages: data.has_more,
-      messagesOffset: data.limit, // Next offset for loading more
+      messagesOffset: data.limit,
       isLoadingMessages: false,
     });
   },
@@ -90,11 +80,10 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
 
   deleteConversation: async (id: number) => {
     await apiClient.deleteConversation(id);
-    const conversations = get().conversations.filter((c) => c.id !== id);
-    set({ conversations, currentConversation: null, messages: [], frames: {} });
+    set({ currentConversation: null, messages: [], frames: {} });
   },
 
-  createNewConversation: () => {
+  clearCurrentConversation: () => {
     set({
       currentConversation: null,
       messages: [],
@@ -127,13 +116,7 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
     });
   },
 
-  setCurrentConversationId: async (id: number) => {
-    const conversation = get().conversations.find((c) => c.id === id) || null;
-    set({ currentConversation: conversation });
-
-    // If conversation not found in current list, it's new - refresh the list
-    if (!conversation) {
-      await get().loadConversations();
-    }
+  setCurrentConversationId: (id: number) => {
+    set({ currentConversation: { id, title: '', frame_count: 0, created_at: '', updated_at: '' } });
   },
 }));

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -15,6 +15,7 @@ const STORAGE_KEYS = {
   SHOW_ADMINISTRATOR: 'kurisu_show_administrator',
   ASR_DEVICE_ID: 'kurisu_asr_device_id',
   SELECTED_AGENT_ID: 'kurisu_selected_agent_id',
+  AGENT_CONVERSATIONS: 'kurisu_agent_conversations',
 } as const;
 
 export const storage = {
@@ -325,6 +326,48 @@ export const storage = {
       localStorage.removeItem(STORAGE_KEYS.SELECTED_AGENT_ID);
     } catch (error) {
       console.error('Failed to clear selected agent ID:', error);
+    }
+  },
+
+  getAgentConversationMap(): Record<string, number> {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEYS.AGENT_CONVERSATIONS);
+      return raw ? JSON.parse(raw) : {};
+    } catch {
+      return {};
+    }
+  },
+
+  getAgentConversationId(agentId: number | 'group'): number | null {
+    const map = this.getAgentConversationMap();
+    return map[String(agentId)] ?? null;
+  },
+
+  setAgentConversationId(agentId: number | 'group', conversationId: number): void {
+    try {
+      const map = this.getAgentConversationMap();
+      map[String(agentId)] = conversationId;
+      localStorage.setItem(STORAGE_KEYS.AGENT_CONVERSATIONS, JSON.stringify(map));
+    } catch (error) {
+      console.error('Failed to save agent conversation mapping:', error);
+    }
+  },
+
+  clearAgentConversationId(agentId: number | 'group'): void {
+    try {
+      const map = this.getAgentConversationMap();
+      delete map[String(agentId)];
+      localStorage.setItem(STORAGE_KEYS.AGENT_CONVERSATIONS, JSON.stringify(map));
+    } catch (error) {
+      console.error('Failed to clear agent conversation mapping:', error);
+    }
+  },
+
+  clearAllAgentConversations(): void {
+    try {
+      localStorage.removeItem(STORAGE_KEYS.AGENT_CONVERSATIONS);
+    } catch (error) {
+      console.error('Failed to clear all agent conversations:', error);
     }
   },
 };


### PR DESCRIPTION
## Summary
- Remove the conversation sidebar entirely — each agent now maps to one conversation via a `kurisu_agent_conversations` localStorage mapping
- Agent selection triggers conversation load (or empty state); first message auto-creates and saves the mapping
- Agent selector dropdown and clear conversation button moved to the top bar
- Mapping cleaned up on logout, agent delete, and conversation clear

## Test plan
- [ ] Select an agent → should show empty chat (first time)
- [ ] Send a message → conversation auto-creates, mapping saved
- [ ] Switch agents → previous agent's conversation preserved, new agent shows empty or its own history
- [ ] Switch back → loads the first agent's conversation
- [ ] Click clear (trash icon) → conversation deleted, shows empty state
- [ ] Send new message after clear → new conversation created
- [ ] Delete an agent in Agents tab → mapping cleaned up
- [ ] Logout/login → mapping cleared, fresh start

🤖 Generated with [Claude Code](https://claude.com/claude-code)