### PR TITLE
Add subtitles to character window, always-on TTS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ src/components/
   UpdateDialog.tsx          — Auto-update notification: shows download progress, "Restart Now" / "Later" on completion
   SettingsWindow.tsx       — Account (backend) + TTS (localStorage) settings tabs
 src/hooks/
-  useTTS.ts               — TTS synthesis/playback: speak(), queueText(), clearQueue()
+  useTTS.ts               — TTS synthesis/playback: speak(), queueText(), clearQueue(), onPlaybackStart subtitle callback, WAV duration parsing
   useAudioAmplitude.ts    — Web Audio API amplitude for lip sync (AudioBufferSourceNode + time-domain RMS)
 src/store/
   authStore.ts            — Auth state, login/register/logout, token persistence
@@ -48,7 +48,7 @@ src/store/
   agentStore.ts           — Agent list (filtered, no Administrator), selected agent ID (persisted). Agent selection triggers conversation load via agent-conversation mapping.
   visionStore.ts          — Zustand singleton: vision pipeline control (getUserMedia webcam capture, frame upload at 3 FPS via WebSocket, face/pose/hands toggles, WebSocket vision_result listener + gesture IPC forwarding). Used by both FacesWindow and ChatWidget camera toggle.
   mediaStore.ts           — Zustand singleton: media player state (playback, track, queue, volume). All media events (control + chunks) flow through wsManager on /ws/chat. Module-level listeners for media_state/media_chunk/media_error. Buffers base64 chunks → Blob → Audio playback. Volume persisted to localStorage.
-src/CharacterWindowApp.tsx — Minimal IPC-driven renderer for separate character window (no auth/stores)
+src/CharacterWindowApp.tsx — Minimal IPC-driven renderer for separate character window (no auth/stores, subtitle overlay)
 src/videocall/            — Character animation engine (rendered in separate Electron window via IPC)
   types.ts                — PoseConfig, PatchInfo, PoseTree, AnimationNode/Edge/EdgeTransition, TransitionCondition (random/thinking/gesture), AnimationSettings, CharacterConfig, migrateEdgeToTransitions(), migratePoseTreeIds() (old pose-*/edge-* IDs → 8-char hex)
   CharacterRenderer.tsx   — React wrapper around CanvasCompositor (accepts PoseTree, amplitude via ref)
@@ -81,12 +81,13 @@ src/config.ts             — API URL config (reads dynamically from storage)
 - On DoneEvent: `loadConversation()` refreshes store from DB, clears streamingMessages
 - Typing indicator: bouncing dots inside bubble before first chunk; "Done" checkmark after
 
-### Streaming TTS Auto-Play
-- Accumulates content in buffer; on sentence boundary (`.!?。！？\n`), queues via `useTTS().queueText()`
+### Streaming TTS (Always On)
+- TTS always active (no toggle). Accumulates content in buffer; on sentence boundary (`.!?。！？\n`), queues via `useTTS().queueText()`
 - Parallel synthesis, sequential FIFO playback
 - Flushes buffer on agent change or DoneEvent; `clearQueue()` on cancel/new send
 - Tool messages excluded; voice reference tracked per-agent
 - Action narration (`*walks over*`) stripped via `stripNarration()` before TTS — preserves `**bold**`
+- **Subtitles**: `useTTS` parses WAV header for duration, calls `onPlaybackStart(text, duration)` before each queue item plays. On TTS error, falls back to 4s duration. ChatWidget forwards to character window via IPC.
 
 ### Conversation Management (One Per Agent)
 - No conversation sidebar — each agent has one conversation, managed via `kurisu_agent_conversations` localStorage mapping (`Record<string, number>`, agent ID → conversation ID)
@@ -137,6 +138,7 @@ Separate Electron window (toggleable via Face icon in top bar). Opens as indepen
 - `character:amplitude` — `{ amplitude, isPlaying, isThinking }` at ~30fps via setInterval
 - `character:agents-update` — `{ agents: [{id, name, poseTree}], activeAgentId }` on agent map or active agent change
 - `character:gesture-update` — `{ gestures: string[] }` forwarded from vision pipeline to trigger pose transitions
+- `character:subtitle` — `{ text: string, isUser: boolean, duration?: number }` subtitles displayed as overlay at bottom of character window. Agent text: `sentenceDuration = chunkDuration / sentenceCount` (chunk split on `.!?。！？\n`). TTS success → chunkDuration = WAV duration; TTS error → chunkDuration = 4s. Sentences queued and shown sequentially, chaining immediately, fade only after last. User text shown immediately with word-count-based hold. Empty text clears (cancel).
 - `character:window-closed` — main process → main renderer when user closes character window
 - `character:open-window` / `character:close-window` — renderer invokes main process to create/destroy window
 
@@ -150,7 +152,7 @@ Separate Electron window (toggleable via Face icon in top bar). Opens as indepen
 
 ## Storage Keys (localStorage)
 
-`kurisu_auth_token`, `kurisu_remember_me`, `kurisu_selected_model`, `kurisu_backend_url`, `kurisu_tts_backend`, `kurisu_tts_voice`, `kurisu_tts_language`, `kurisu_tts_auto_play`, `kurisu_tts_emo_audio`, `kurisu_tts_emo_alpha`, `kurisu_tts_use_emo_text`, `kurisu_selected_agent_id`, `kurisu_agent_conversations`, `kurisu_media_volume`
+`kurisu_auth_token`, `kurisu_remember_me`, `kurisu_selected_model`, `kurisu_backend_url`, `kurisu_tts_backend`, `kurisu_tts_voice`, `kurisu_tts_language`, `kurisu_tts_emo_audio`, `kurisu_tts_emo_alpha`, `kurisu_tts_use_emo_text`, `kurisu_selected_agent_id`, `kurisu_agent_conversations`, `kurisu_media_volume`
 
 ## Security
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -136,6 +136,13 @@ ipcMain.on('character:face-update', (_event, data) => {
   }
 });
 
+// IPC relay: subtitle from main renderer → character renderer
+ipcMain.on('character:subtitle', (_event, data) => {
+  if (characterWindow && !characterWindow.isDestroyed()) {
+    characterWindow.webContents.send('character:subtitle', data);
+  }
+});
+
 // --- App Lifecycle ---
 
 app.whenReady().then(() => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -64,6 +64,14 @@ contextBridge.exposeInMainWorld('electron', {
       return () => { ipcRenderer.removeListener('character:face-update', handler); };
     },
 
+    sendSubtitle: (data: { text: string; isUser: boolean }) =>
+      ipcRenderer.send('character:subtitle', data),
+    onSubtitle: (cb: (data: { text: string; isUser: boolean }) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, data: { text: string; isUser: boolean }) => cb(data);
+      ipcRenderer.on('character:subtitle', handler);
+      return () => { ipcRenderer.removeListener('character:subtitle', handler); };
+    },
+
     signalReady: () => ipcRenderer.send('character:ready'),
     onCharacterReady: (cb: () => void) => {
       const handler = () => cb();

--- a/src/CharacterWindowApp.tsx
+++ b/src/CharacterWindowApp.tsx
@@ -11,6 +11,12 @@ interface AgentEntry {
 export const CharacterWindowApp: React.FC = () => {
   const [agentMap, setAgentMap] = useState<Map<number, AgentEntry>>(new Map());
   const [activeAgentId, setActiveAgentId] = useState<number | null>(null);
+  const [subtitleText, setSubtitleText] = useState('');
+  const [subtitleVisible, setSubtitleVisible] = useState(false);
+  const [subtitleIsUser, setSubtitleIsUser] = useState(false);
+  const subtitleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const subtitleQueueRef = useRef<Array<{ text: string; durationMs: number }>>([]);
+  const subtitleDrainingRef = useRef(false);
   const amplitudeRef = useRef<AmplitudeState>({ amplitude: 0, isPlaying: false, isThinking: false });
   const silentRef = useRef<AmplitudeState>({ amplitude: 0, isPlaying: false, isThinking: false });
   const gesturesRef = useRef<string[]>([]);
@@ -58,6 +64,66 @@ export const CharacterWindowApp: React.FC = () => {
       facesRef.current = data.faces;
     });
 
+    // Helper: clear subtitle timer
+    const clearSubtitleTimer = () => {
+      if (subtitleTimerRef.current) { clearTimeout(subtitleTimerRef.current); subtitleTimerRef.current = null; }
+    };
+
+    // Split text into sentences on .!?。！？\n boundaries
+    const splitSentences = (text: string): string[] =>
+      text.split(/(?<=[.!?。！？\n])\s*/).map(s => s.trim()).filter(Boolean);
+
+    // Queue drain: show one sentence at a time for its duration, fade only after last
+    const drainQueue = () => {
+      if (subtitleQueueRef.current.length === 0) {
+        subtitleDrainingRef.current = false;
+        subtitleTimerRef.current = setTimeout(() => setSubtitleVisible(false), 1000);
+        return;
+      }
+      subtitleDrainingRef.current = true;
+      const item = subtitleQueueRef.current.shift()!;
+      setSubtitleText(item.text);
+      setSubtitleIsUser(false);
+      setSubtitleVisible(true);
+      subtitleTimerRef.current = setTimeout(drainQueue, item.durationMs);
+    };
+
+    const cleanupSubtitle = api.onSubtitle((data) => {
+      if (!data.text) {
+        // Cancel: clear everything and hide
+        clearSubtitleTimer();
+        subtitleQueueRef.current = [];
+        subtitleDrainingRef.current = false;
+        setSubtitleVisible(false);
+        return;
+      }
+
+      if (data.isUser) {
+        // User text: show immediately, interrupt queue
+        clearSubtitleTimer();
+        subtitleQueueRef.current = [];
+        subtitleDrainingRef.current = false;
+        setSubtitleText(data.text);
+        setSubtitleIsUser(true);
+        setSubtitleVisible(true);
+        const words = data.text.split(/\s+/).filter(Boolean);
+        const displayMs = Math.max(1500, words.length * 350);
+        subtitleTimerRef.current = setTimeout(() => setSubtitleVisible(false), displayMs);
+      } else {
+        // Agent text: split into sentences, push to queue, let drain handle timing
+        const chunkDurationMs = (data.duration || 4) * 1000;
+        const sentences = splitSentences(data.text);
+        if (!sentences.length) return;
+        const perSentenceMs = chunkDurationMs / sentences.length;
+        for (const sentence of sentences) {
+          subtitleQueueRef.current.push({ text: sentence, durationMs: perSentenceMs });
+        }
+        if (!subtitleDrainingRef.current) {
+          drainQueue();
+        }
+      }
+    });
+
     // Signal to main renderer that listeners are ready — triggers initial data push
     api.signalReady();
 
@@ -66,6 +132,9 @@ export const CharacterWindowApp: React.FC = () => {
       cleanupAgents();
       cleanupGestures();
       cleanupFaces();
+      cleanupSubtitle();
+      if (subtitleTimerRef.current) clearTimeout(subtitleTimerRef.current);
+      subtitleQueueRef.current = [];
     };
   }, []);
 
@@ -85,6 +154,41 @@ export const CharacterWindowApp: React.FC = () => {
         overflow: 'hidden',
       }}
     >
+      {/* Subtitle overlay */}
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 28,
+          left: 0,
+          right: 0,
+          zIndex: 10,
+          display: 'flex',
+          justifyContent: 'center',
+          pointerEvents: 'none',
+          // @ts-expect-error Electron CSS property
+          WebkitAppRegion: 'no-drag',
+        }}
+      >
+        <div
+          style={{
+            maxWidth: '90%',
+            padding: subtitleText ? '6px 16px' : 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.65)',
+            borderRadius: 8,
+            color: '#fff',
+            fontSize: 15,
+            lineHeight: 1.4,
+            textAlign: 'center',
+            fontStyle: subtitleIsUser ? 'italic' : 'normal',
+            opacity: subtitleVisible ? (subtitleIsUser ? 0.7 : 1) : 0,
+            transition: 'opacity 0.4s ease',
+            wordBreak: 'break-word',
+          }}
+        >
+          {subtitleText}
+        </div>
+      </div>
+
       {agentMap.size === 0 ? (
         <div
           style={{

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -84,8 +84,13 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
   const [activeAgentId, setActiveAgentId] = useState<number | null>(null);
   const agentCacheRef = useRef<Set<number>>(new Set()); // IDs already fetched
 
+  // Subtitle: send TTS segment text + duration to character window for word-by-word reveal
+  const onTTSPlaybackStart = useCallback((text: string, duration: number) => {
+    window.electron?.characterWindow?.sendSubtitle({ text, isUser: false, duration });
+  }, []);
+
   // Streaming TTS auto-play (with amplitude callback for character lip sync)
-  const { speak, stop: stopTTS, isPlaying: isTTSPlaying, queueText, clearQueue, isQueueActive } = useTTS(onAmplitudeUpdate);
+  const { speak, stop: stopTTS, isPlaying: isTTSPlaying, queueText, clearQueue, isQueueActive } = useTTS(onAmplitudeUpdate, onTTSPlaybackStart);
   // Expose TTS functions via ref so MessageBubble can use the amplitude-aware instance
   // without causing re-renders on every isTTSPlaying change
   const setActiveAgentForTTS = useCallback((agentId: number | null) => {
@@ -398,7 +403,7 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
 
     if (needsNewBubble) {
       // Flush TTS buffer from previous agent before switching
-      if (storage.getTTSAutoPlay() && ttsBufferRef.current.trim()) {
+      if (ttsBufferRef.current.trim()) {
         const cleaned = stripNarration(ttsBufferRef.current);
         if (cleaned) queueText(cleaned, ttsVoiceRef.current);
         ttsBufferRef.current = '';
@@ -501,7 +506,8 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     }
 
     // Streaming TTS auto-play: feed complete sentences to TTS queue
-    if (storage.getTTSAutoPlay() && event.content && event.role !== 'tool') {
+    // Streaming TTS: feed complete sentences to TTS queue
+    if (event.content && event.role !== 'tool') {
       ttsVoiceRef.current = event.voice_reference || ttsVoiceRef.current;
       ttsBufferRef.current += event.content;
 
@@ -530,7 +536,7 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     amplitudeRef.current = { ...amplitudeRef.current, isThinking: false };
 
     // Flush remaining TTS buffer
-    if (storage.getTTSAutoPlay() && ttsBufferRef.current.trim()) {
+    if (ttsBufferRef.current.trim()) {
       const cleaned = stripNarration(ttsBufferRef.current);
       if (cleaned) queueText(cleaned, ttsVoiceRef.current);
     }
@@ -672,6 +678,9 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
         images: [], // Will be handled differently
       };
 
+      // Send user text as subtitle
+      window.electron?.characterWindow?.sendSubtitle({ text: input.trim(), isUser: true });
+
       // Add user message + placeholder to local streaming state (not store)
       setStreamingMessages([userMessage, { role: 'assistant', content: '' }]);
 
@@ -726,6 +735,9 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     clearQueue();
     ttsBufferRef.current = '';
     ttsVoiceRef.current = undefined;
+
+    // Clear subtitle
+    window.electron?.characterWindow?.sendSubtitle({ text: '', isUser: false });
 
     // Finalize streaming messages with partial content
     const state = streamingStateRef.current;

--- a/src/components/SettingsWindow.tsx
+++ b/src/components/SettingsWindow.tsx
@@ -56,7 +56,6 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ onBack }) => {
 
   // TTS settings — auto-saved to localStorage on change
   const [ttsBackend, setTtsBackendState] = useState(storage.getTTSBackend() || 'gpt-sovits');
-  const [ttsAutoPlay, setTtsAutoPlayState] = useState(storage.getTTSAutoPlay());
 
   // INDEX-TTS emotion settings
   const [ttsEmotionAudio, setTtsEmotionAudioState] = useState(storage.getTTSEmotionAudio() || '');
@@ -65,7 +64,6 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ onBack }) => {
 
   // Auto-save wrappers
   const setTtsBackend = (v: string) => { setTtsBackendState(v); storage.setTTSBackend(v); };
-  const setTtsAutoPlay = (v: boolean) => { setTtsAutoPlayState(v); storage.setTTSAutoPlay(v); };
   const setTtsEmotionAudio = (v: string) => { setTtsEmotionAudioState(v); storage.setTTSEmotionAudio(v); };
   const setTtsEmotionAlpha = (v: number) => { setTtsEmotionAlphaState(v); storage.setTTSEmotionAlpha(v); };
   const setTtsUseEmotionText = (v: boolean) => { setTtsUseEmotionTextState(v); storage.setTTSUseEmotionText(v); };
@@ -308,19 +306,6 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ onBack }) => {
                 ))}
               </Select>
             </FormControl>
-          </Box>
-
-          {/* TTS Auto-Play */}
-          <Box sx={{ mb: 4 }}>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={ttsAutoPlay}
-                  onChange={(e) => setTtsAutoPlay(e.target.checked)}
-                />
-              }
-              label="Auto-play assistant messages"
-            />
           </Box>
 
           {/* INDEX-TTS Emotion Controls - Only show when backend is index-tts */}

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -4,10 +4,38 @@ import { storage } from '../utils/storage';
 import { useAudioAmplitude } from './useAudioAmplitude';
 
 /**
- * @param onAmplitudeUpdate - Optional callback invoked at ~30fps with amplitude (0-1)
- *   when character panel is active. If not provided, uses plain Audio playback.
+ * Parse WAV header to get audio duration in seconds.
  */
-export function useTTS(onAmplitudeUpdate?: (amplitude: number, isPlaying: boolean) => void) {
+function getWavDuration(buffer: ArrayBuffer): number | null {
+  const view = new DataView(buffer);
+  if (view.byteLength < 44) return null;
+
+  let byteRate = 0;
+  let dataSize = 0;
+  let offset = 12;
+  while (offset + 8 <= view.byteLength) {
+    const id = String.fromCharCode(
+      view.getUint8(offset), view.getUint8(offset + 1),
+      view.getUint8(offset + 2), view.getUint8(offset + 3),
+    );
+    const size = view.getUint32(offset + 4, true);
+    if (id === 'fmt ') {
+      byteRate = view.getUint32(offset + 16, true);
+    } else if (id === 'data') {
+      dataSize = size;
+      break;
+    }
+    offset += 8 + size;
+    if (size % 2 !== 0) offset++;
+  }
+  if (byteRate === 0 || dataSize === 0) return null;
+  return dataSize / byteRate;
+}
+
+export function useTTS(
+  onAmplitudeUpdate?: (amplitude: number, isPlaying: boolean) => void,
+  onPlaybackStart?: (text: string, duration: number) => void,
+) {
   const [isPlaying, setIsPlaying] = useState(false);
   const [voices, setVoices] = useState<string[]>([]);
   const [backends, setBackends] = useState<string[]>([]);
@@ -17,9 +45,11 @@ export function useTTS(onAmplitudeUpdate?: (amplitude: number, isPlaying: boolea
   const amplitudeController = useAudioAmplitude();
   const amplitudeCallbackRef = useRef(onAmplitudeUpdate);
   amplitudeCallbackRef.current = onAmplitudeUpdate;
+  const playbackStartCallbackRef = useRef(onPlaybackStart);
+  playbackStartCallbackRef.current = onPlaybackStart;
 
   // Queue-based streaming TTS state
-  const ttsQueueRef = useRef<Array<{ audioPromise: Promise<Blob> }>>([]);
+  const ttsQueueRef = useRef<Array<{ audioPromise: Promise<Blob>; text: string }>>([]);
   const isPlayingQueueRef = useRef(false);
   const currentQueueAudioRef = useRef<HTMLAudioElement | null>(null);
   const [isQueueActive, setIsQueueActive] = useState(false);
@@ -162,9 +192,18 @@ export function useTTS(onAmplitudeUpdate?: (amplitude: number, isPlaying: boolea
       const item = ttsQueueRef.current.shift()!;
       try {
         const blob = await item.audioPromise;
+        // Notify subtitle system with text + audio duration before playback
+        const psCb = playbackStartCallbackRef.current;
+        if (psCb) {
+          const duration = getWavDuration(await blob.arrayBuffer());
+          if (duration) psCb(item.text, duration);
+        }
         await playBlobAsync(blob, cb || undefined);
       } catch (e) {
         console.error('TTS queue playback error:', e);
+        // TTS failed — still send subtitle with 4s fallback duration
+        const psCb = playbackStartCallbackRef.current;
+        if (psCb) psCb(item.text, 4);
       }
     }
 
@@ -189,8 +228,9 @@ export function useTTS(onAmplitudeUpdate?: (amplitude: number, isPlaying: boolea
         }
       : undefined;
 
-    const audioPromise = apiClient.synthesize(text.trim(), voice, undefined, backend, emotionParams);
-    ttsQueueRef.current.push({ audioPromise });
+    const trimmed = text.trim();
+    const audioPromise = apiClient.synthesize(trimmed, voice, undefined, backend, emotionParams);
+    ttsQueueRef.current.push({ audioPromise, text: trimmed });
     setIsQueueActive(true);
 
     if (!isPlayingQueueRef.current) {

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -13,10 +13,12 @@ export interface CharacterWindowAPI {
   sendAgentsUpdate: (data: { agents: AgentData[]; activeAgentId: number | null }) => void;
   sendGestureUpdate: (data: { gestures: string[] }) => void;
   sendFaceUpdate: (data: { faces: string[] }) => void;
+  sendSubtitle: (data: { text: string; isUser: boolean; duration?: number }) => void;
   onAmplitude: (cb: (data: { amplitude: number; isPlaying: boolean; isThinking: boolean }) => void) => () => void;
   onAgentsUpdate: (cb: (data: { agents: AgentData[]; activeAgentId: number | null }) => void) => () => void;
   onGestureUpdate: (cb: (data: { gestures: string[] }) => void) => () => void;
   onFaceUpdate: (cb: (data: { faces: string[] }) => void) => () => void;
+  onSubtitle: (cb: (data: { text: string; isUser: boolean; duration?: number }) => void) => () => void;
   onWindowClosed: (cb: () => void) => () => void;
   signalReady: () => void;
   onCharacterReady: (cb: () => void) => () => void;


### PR DESCRIPTION
## Summary
- Subtitle overlay in character window shows agent responses sentence-by-sentence, timed to TTS audio duration (`sentenceDuration = chunkDuration / sentenceCount`)
- WAV header parsed for duration; 4s fallback on TTS synthesis error
- User text shown immediately on send with word-count-based hold
- TTS is now always active — removed the auto-play toggle from settings
- New IPC channel `character:subtitle` with full relay pipeline (preload → main → character renderer)

## Test plan
- [ ] Open character window, send a message → user text appears briefly as subtitle
- [ ] Agent responds → subtitles appear sentence-by-sentence synced to TTS audio
- [ ] Sentences chain immediately, fade only after the last one
- [ ] Cancel stream → subtitle clears
- [ ] Disconnect TTS backend → subtitles still show with 4s fallback timing
- [ ] Settings no longer shows TTS auto-play toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)