### PR TITLE
Add context window display mode, token usage, and slash commands

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -70,6 +70,9 @@ export interface ConversationDetail {
   offset: number;
   limit: number;
   has_more: boolean;
+  compacted_up_to_id: number;
+  compacted_context: string;
+  system_prompt_token_count: number;
 }
 
 export interface UserProfile {

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -166,6 +166,8 @@ export interface ContextInfoEvent extends BaseEvent {
   type: 'context_info';
   conversation_id: number;
   compacting: boolean;
+  compacted_up_to_id: number;
+  compacted_context: string;
 }
 
 export interface ConnectedEvent extends BaseEvent {

--- a/src/components/chat/ChatComposer.tsx
+++ b/src/components/chat/ChatComposer.tsx
@@ -82,6 +82,7 @@ export const ChatComposer: React.FC<ChatComposerProps> = React.memo(({
   const [input, setInput] = useState('');
   const [images, setImages] = useState<File[]>([]);
   const [commandIdx, setCommandIdx] = useState(-1);
+  const [commandSelected, setCommandSelected] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textFieldRef = useRef<HTMLDivElement>(null);
 
@@ -94,7 +95,7 @@ export const ChatComposer: React.FC<ChatComposerProps> = React.memo(({
     return allCommands.filter((c) => c.name.startsWith(query));
   }, [input, allCommands]);
 
-  const showCommands = filteredCommands.length > 0 && !isStreaming;
+  const showCommands = filteredCommands.length > 0 && !isStreaming && !commandSelected;
 
   useEffect(() => {
     setInput('');
@@ -127,6 +128,7 @@ export const ChatComposer: React.FC<ChatComposerProps> = React.memo(({
   const selectCommand = useCallback((name: string) => {
     setInput(`/${name}`);
     setCommandIdx(-1);
+    setCommandSelected(true);
   }, []);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -282,7 +284,7 @@ export const ChatComposer: React.FC<ChatComposerProps> = React.memo(({
           multiline
           maxRows={4}
           value={input}
-          onChange={(e) => { setInput(e.target.value); setCommandIdx(-1); }}
+          onChange={(e) => { setInput(e.target.value); setCommandIdx(-1); setCommandSelected(false); }}
           onKeyDown={handleKeyDown}
           placeholder="Type your message..."
           disabled={isStreaming}

--- a/src/components/chat/ChatComposer.tsx
+++ b/src/components/chat/ChatComposer.tsx
@@ -143,9 +143,10 @@ export const ChatComposer: React.FC<ChatComposerProps> = React.memo(({
         setCommandIdx((prev) => Math.max(prev - 1, -1));
         return;
       }
-      if ((e.key === 'Tab' || e.key === 'Enter') && commandIdx >= 0) {
+      if (e.key === 'Tab' || e.key === 'Enter') {
         e.preventDefault();
-        selectCommand(filteredCommands[commandIdx].name);
+        const idx = commandIdx >= 0 ? commandIdx : 0;
+        selectCommand(filteredCommands[idx].name);
         return;
       }
     }

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -396,6 +396,16 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
           {streaming.errorToast}
         </Alert>
       </Snackbar>
+      <Snackbar
+        open={!!streaming.infoToast}
+        autoHideDuration={3000}
+        onClose={() => streaming.setInfoToast(null)}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      >
+        <Alert onClose={() => streaming.setInfoToast(null)} severity="info" variant="filled" sx={{ width: '100%' }}>
+          {streaming.infoToast}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 };

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -179,15 +179,16 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     return messages;
   }, [messages, displayMode, compactedUpToId]);
 
-  // Token count: compacted context + context window messages (including streaming)
+  // Token count: compacted context + context window messages + live streaming content
   const tokenCount = useMemo(() => {
     const contextMsgs = messages.filter(m => (m.id ?? Infinity) > compactedUpToId);
     const allMsgs = [...contextMsgs, ...streaming.streamingMessages];
     const wc = (t: string | undefined) => t ? t.split(/\s+/).length : 0;
     const msgWords = allMsgs.reduce((n, m) => n + wc(m.content) + wc(m.thinking), 0);
+    const liveWords = wc(streaming.streamingContent) + wc(streaming.streamingThinking);
     const contextWords = wc(compactedContext);
-    return Math.round((msgWords + contextWords) * 1.3);
-  }, [messages, compactedUpToId, compactedContext, streaming.streamingMessages]);
+    return Math.round((msgWords + liveWords + contextWords) * 1.3);
+  }, [messages, compactedUpToId, compactedContext, streaming.streamingMessages, streaming.streamingContent, streaming.streamingThinking]);
 
   // Message rendering
   const messageElements = useMemo(() => {

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -45,7 +45,7 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     loadConversation,
     setCurrentConversationId,
   } = useConversationStore();
-  const { compactedUpToId, compactedContext, systemPromptTokenCount } = useConversationStore();
+  const { compactedUpToId, compactedContext } = useConversationStore();
   const contextSize = useAuthStore((s) => s.user?.context_size) || 8192;
 
   // Display mode: "all" shows full history, "context" shows only LLM context window
@@ -179,17 +179,15 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     return messages;
   }, [messages, displayMode, compactedUpToId]);
 
-  // Token count estimation (frontend-calculated, all context window content)
-  const estimatedTokens = useMemo(() => {
+  // Token count: compacted context + context window messages (including streaming)
+  const tokenCount = useMemo(() => {
     const contextMsgs = messages.filter(m => (m.id ?? Infinity) > compactedUpToId);
     const allMsgs = [...contextMsgs, ...streaming.streamingMessages];
-    const wordCount = (text: string | undefined) => text ? text.split(/\s+/).length : 0;
-    const msgWords = allMsgs.reduce((n, m) => n + wordCount(m.content) + wordCount(m.thinking), 0);
-    const contextWords = wordCount(compactedContext);
-    return systemPromptTokenCount + Math.round((msgWords + contextWords) * 1.3);
-  }, [messages, compactedUpToId, compactedContext, systemPromptTokenCount, streaming.streamingMessages]);
-
-  const tokenCount = streaming.contextTokens || estimatedTokens;
+    const wc = (t: string | undefined) => t ? t.split(/\s+/).length : 0;
+    const msgWords = allMsgs.reduce((n, m) => n + wc(m.content) + wc(m.thinking), 0);
+    const contextWords = wc(compactedContext);
+    return Math.round((msgWords + contextWords) * 1.3);
+  }, [messages, compactedUpToId, compactedContext, streaming.streamingMessages]);
 
   // Message rendering
   const messageElements = useMemo(() => {

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -179,13 +179,15 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     return messages;
   }, [messages, displayMode, compactedUpToId]);
 
-  // Token count estimation (frontend-calculated)
+  // Token count estimation (frontend-calculated, all context window content)
   const estimatedTokens = useMemo(() => {
     const contextMsgs = messages.filter(m => (m.id ?? Infinity) > compactedUpToId);
-    const msgWords = contextMsgs.reduce((n, m) => n + (m.content?.split(/\s+/).length || 0), 0);
-    const contextWords = compactedContext ? compactedContext.split(/\s+/).length : 0;
+    const allMsgs = [...contextMsgs, ...streaming.streamingMessages];
+    const wordCount = (text: string | undefined) => text ? text.split(/\s+/).length : 0;
+    const msgWords = allMsgs.reduce((n, m) => n + wordCount(m.content) + wordCount(m.thinking), 0);
+    const contextWords = wordCount(compactedContext);
     return systemPromptTokenCount + Math.round((msgWords + contextWords) * 1.3);
-  }, [messages, compactedUpToId, compactedContext, systemPromptTokenCount]);
+  }, [messages, compactedUpToId, compactedContext, systemPromptTokenCount, streaming.streamingMessages]);
 
   const tokenCount = streaming.contextTokens || estimatedTokens;
 

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -211,6 +211,7 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
       lastFrameId = currentFrameId;
 
       const isActiveStreaming = message === activeStreamingMsg;
+      const isCompacted = message.id != null && message.id <= compactedUpToId;
       elements.push(
         <MessageBubble
           key={message.id ? `msg-${message.id}` : `stream-${index}`}
@@ -225,7 +226,7 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
           justFinishedStreaming={index === combined.length - 1 && streaming.justFinishedStreaming}
           expandedThinking={streaming.expandedThinking}
           onToggleThinking={streaming.toggleThinking}
-          onResend={streaming.handleResend}
+          onResend={isCompacted ? undefined : streaming.handleResend}
           onDelete={streaming.handleDelete}
           ttsRef={ttsRef}
         />
@@ -245,6 +246,7 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     streaming.toggleThinking,
     streaming.handleResend,
     streaming.handleDelete,
+    compactedUpToId,
   ]);
 
   const messagesPane = useMemo(() => (

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -383,23 +383,6 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
           }}
         />
       )}
-      {(streaming.contextTokens > 0 || streaming.isCompacting) && (
-        <Typography
-          variant="caption"
-          color="text.secondary"
-          sx={{ textAlign: 'right', px: 2, py: 0.5, fontSize: '0.7rem' }}
-        >
-          {streaming.isCompacting && 'Compacting context... '}
-          {streaming.contextTokens > 0 && (
-            <>
-              {streaming.contextTokens >= 1000
-                ? `${(streaming.contextTokens / 1000).toFixed(1)}k`
-                : streaming.contextTokens}
-              {' tokens'}
-            </>
-          )}
-        </Typography>
-      )}
       <Snackbar
         open={!!streaming.errorToast}
         autoHideDuration={6000}

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -179,16 +179,16 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     return messages;
   }, [messages, displayMode, compactedUpToId]);
 
-  // Token count: compacted context + context window messages + live streaming content
-  const tokenCount = useMemo(() => {
+  // Token count: backend value during streaming, frontend estimate at rest
+  const estimatedTokens = useMemo(() => {
     const contextMsgs = messages.filter(m => (m.id ?? Infinity) > compactedUpToId);
-    const allMsgs = [...contextMsgs, ...streaming.streamingMessages];
     const wc = (t: string | undefined) => t ? t.split(/\s+/).length : 0;
-    const msgWords = allMsgs.reduce((n, m) => n + wc(m.content) + wc(m.thinking), 0);
-    const liveWords = wc(streaming.streamingContent) + wc(streaming.streamingThinking);
+    const msgWords = contextMsgs.reduce((n, m) => n + wc(m.content) + wc(m.thinking), 0);
     const contextWords = wc(compactedContext);
-    return Math.round((msgWords + liveWords + contextWords) * 1.3);
-  }, [messages, compactedUpToId, compactedContext, streaming.streamingMessages, streaming.streamingContent, streaming.streamingThinking]);
+    return Math.round((msgWords + contextWords) * 1.3);
+  }, [messages, compactedUpToId, compactedContext]);
+
+  const tokenCount = streaming.contextTokens || estimatedTokens;
 
   // Message rendering
   const messageElements = useMemo(() => {

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -4,10 +4,18 @@ import {
   Typography,
   Snackbar,
   Alert,
+  ToggleButtonGroup,
+  ToggleButton,
+  Collapse,
+  Paper,
+  IconButton,
 } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 
 import { AnimatePresence } from 'framer-motion';
 import { useConversationStore } from '../../store/conversationStore';
+import { useAuthStore } from '../../store/authStore';
 
 import { useTTS } from '../../hooks/useTTS';
 import { useVisionStore } from '../../store/visionStore';
@@ -37,6 +45,12 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     loadConversation,
     setCurrentConversationId,
   } = useConversationStore();
+  const { compactedUpToId, compactedContext, systemPromptTokenCount } = useConversationStore();
+  const contextSize = useAuthStore((s) => s.user?.context_size) || 8192;
+
+  // Display mode: "all" shows full history, "context" shows only LLM context window
+  const [displayMode, setDisplayMode] = useState<'all' | 'context'>('all');
+  const [contextBannerExpanded, setContextBannerExpanded] = useState(false);
 
   // Character panel hook
   const {
@@ -74,6 +88,12 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     amplitudeRef,
     pushAgentCharacterConfig,
   });
+
+  // Reset display mode on conversation change
+  useEffect(() => {
+    setDisplayMode('all');
+    setContextBannerExpanded(false);
+  }, [currentConversation?.id]);
 
   // Clear active speaker when TTS queue finishes playing
   useEffect(() => {
@@ -151,9 +171,27 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     setHostApproval(null);
   }, [hostApproval]);
 
+  // Filter messages based on display mode
+  const displayedMessages = useMemo(() => {
+    if (displayMode === 'context') {
+      return messages.filter(m => (m.id ?? Infinity) > compactedUpToId);
+    }
+    return messages;
+  }, [messages, displayMode, compactedUpToId]);
+
+  // Token count estimation (frontend-calculated)
+  const estimatedTokens = useMemo(() => {
+    const contextMsgs = messages.filter(m => (m.id ?? Infinity) > compactedUpToId);
+    const msgWords = contextMsgs.reduce((n, m) => n + (m.content?.split(/\s+/).length || 0), 0);
+    const contextWords = compactedContext ? compactedContext.split(/\s+/).length : 0;
+    return systemPromptTokenCount + Math.round((msgWords + contextWords) * 1.3);
+  }, [messages, compactedUpToId, compactedContext, systemPromptTokenCount]);
+
+  const tokenCount = streaming.contextTokens || estimatedTokens;
+
   // Message rendering
   const messageElements = useMemo(() => {
-    const combined = [...messages, ...streaming.streamingMessages];
+    const combined = [...displayedMessages, ...streaming.streamingMessages];
     const activeStreamingMsg = streaming.isStreaming && streaming.streamingMessages.length > 0
       ? streaming.streamingMessages[streaming.streamingMessages.length - 1]
       : null;
@@ -196,7 +234,7 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
 
     return elements;
   }, [
-    messages,
+    displayedMessages,
     streaming.streamingMessages,
     streaming.isStreaming,
     frames,
@@ -221,7 +259,7 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
         minWidth: 0,
       }}
     >
-      {isLoadingMessages && (
+      {isLoadingMessages && displayMode === 'all' && (
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
           <Typography variant="body2" color="text.secondary">
             Loading earlier messages...
@@ -229,17 +267,59 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
         </Box>
       )}
 
+      {displayMode === 'context' && compactedContext && (
+        <Paper variant="outlined" sx={{ mx: 1, mb: 2, p: 1.5, bgcolor: 'action.hover', borderStyle: 'dashed' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Typography variant="caption" color="text.secondary" fontWeight={600}>
+              Context Summary
+            </Typography>
+            <IconButton size="small" onClick={() => setContextBannerExpanded(v => !v)}>
+              {contextBannerExpanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+            </IconButton>
+          </Box>
+          <Collapse in={contextBannerExpanded}>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5, whiteSpace: 'pre-wrap' }}>
+              {compactedContext}
+            </Typography>
+          </Collapse>
+          {!contextBannerExpanded && (
+            <Typography variant="body2" color="text.secondary" noWrap>
+              {compactedContext.slice(0, 150)}{compactedContext.length > 150 ? '...' : ''}
+            </Typography>
+          )}
+        </Paper>
+      )}
+
       <AnimatePresence>
         {messageElements}
       </AnimatePresence>
       <div ref={streaming.messagesEndRef} />
     </Box>
-  ), [isLoadingMessages, messageElements]);
+  ), [isLoadingMessages, messageElements, displayMode, compactedContext, contextBannerExpanded]);
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0, height: '100%' }}>
 
       {messagesPane}
+
+      {/* Display mode toggle + token usage */}
+      {currentConversation && (
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: 2, py: 0.5 }}>
+          <ToggleButtonGroup
+            value={displayMode}
+            exclusive
+            onChange={(_, v) => v && setDisplayMode(v)}
+            size="small"
+            sx={{ '& .MuiToggleButton-root': { px: 1.5, py: 0.25, fontSize: '0.7rem', textTransform: 'none' } }}
+          >
+            <ToggleButton value="all">All</ToggleButton>
+            <ToggleButton value="context">Context</ToggleButton>
+          </ToggleButtonGroup>
+          <Typography variant="caption" color="text.secondary">
+            {tokenCount.toLocaleString()} / {contextSize.toLocaleString()} tokens
+          </Typography>
+        </Box>
+      )}
 
       {/* Selection context chips — above input */}
       <SelectionChips />

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -300,8 +300,6 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0, height: '100%' }}>
 
-      {messagesPane}
-
       {/* Display mode toggle + token usage */}
       {currentConversation && (
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: 2, py: 0.5 }}>
@@ -320,6 +318,8 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
           </Typography>
         </Box>
       )}
+
+      {messagesPane}
 
       {/* Selection context chips — above input */}
       <SelectionChips />

--- a/src/hooks/useStreamingChat.ts
+++ b/src/hooks/useStreamingChat.ts
@@ -675,8 +675,9 @@ export function useStreamingChat({
     if (!text.trim() || isStreaming) return;
     const trimmed = text.trim();
 
-    // Handle slash commands (e.g. /compact)
-    if (trimmed.startsWith('/') && handleCommand(trimmed, { activeConversationId, agentId })) {
+    // Slash commands are always client-side — never send to backend
+    if (trimmed.startsWith('/')) {
+      handleCommand(trimmed, { activeConversationId, agentId });
       return;
     }
 

--- a/src/hooks/useStreamingChat.ts
+++ b/src/hooks/useStreamingChat.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { wsManager, StreamChunkEvent, DoneEvent, ErrorEvent, ConnectedEvent, ToolApprovalRequestEvent, ContextInfoEvent } from '../api/websocket';
+import { useConversationStore } from '../store/conversationStore';
 import { storage } from '../utils/storage';
 import { stripNarration, fileToBase64 } from '../utils/chat';
 import { useExplorerStore } from '../store/explorerStore';
@@ -502,6 +503,12 @@ export function useStreamingChat({
     const onApproval = (e: ToolApprovalRequestEvent) => setPendingApproval(e);
     const onContextInfo = (e: ContextInfoEvent) => {
       setIsCompacting(e.compacting);
+      if (!e.compacting && e.compacted_up_to_id) {
+        useConversationStore.getState().updateCompactionData(
+          e.compacted_up_to_id,
+          e.compacted_context ?? '',
+        );
+      }
     };
 
     wsManager.on('stream_chunk', onChunk);

--- a/src/hooks/useStreamingChat.ts
+++ b/src/hooks/useStreamingChat.ts
@@ -503,11 +503,18 @@ export function useStreamingChat({
     const onApproval = (e: ToolApprovalRequestEvent) => setPendingApproval(e);
     const onContextInfo = (e: ContextInfoEvent) => {
       setIsCompacting(e.compacting);
-      if (!e.compacting && e.compacted_up_to_id) {
-        useConversationStore.getState().updateCompactionData(
-          e.compacted_up_to_id,
-          e.compacted_context ?? '',
-        );
+      if (!e.compacting) {
+        if (e.compacted_up_to_id) {
+          useConversationStore.getState().updateCompactionData(
+            e.compacted_up_to_id,
+            e.compacted_context ?? '',
+          );
+        }
+        // Reload conversation to refresh compaction data from API
+        const convId = useConversationStore.getState().currentConversation?.id;
+        if (convId) {
+          useConversationStore.getState().loadConversation(convId);
+        }
       }
     };
 

--- a/src/hooks/useStreamingChat.ts
+++ b/src/hooks/useStreamingChat.ts
@@ -37,6 +37,8 @@ export interface UseStreamingChatReturn {
   activeConversationId: number | null;
   errorToast: string | null;
   setErrorToast: (v: string | null) => void;
+  infoToast: string | null;
+  setInfoToast: (v: string | null) => void;
   externalDraft: string;
   externalDraftVersion: number;
   pushExternalDraft: (text: string) => void;
@@ -82,6 +84,7 @@ export function useStreamingChat({
     currentConversation?.id || null
   );
   const [errorToast, setErrorToast] = useState<string | null>(null);
+  const [infoToast, setInfoToast] = useState<string | null>(null);
   const [pendingApproval, setPendingApproval] = useState<ToolApprovalRequestEvent | null>(null);
   const [contextTokens, setContextTokens] = useState(0);
   const [isCompacting, setIsCompacting] = useState(false);
@@ -381,9 +384,10 @@ export function useStreamingChat({
       amplitudeRef.current = { ...amplitudeRef.current, isThinking: false };
     }
 
-    // Update running token count from server
+    // Update running token count from server and persist to store
     if (event.token_count != null) {
       setContextTokens(event.token_count);
+      useConversationStore.getState().setLastTokenCount(event.token_count);
     }
 
     // Streaming TTS auto-play: feed complete sentences to TTS queue
@@ -677,7 +681,8 @@ export function useStreamingChat({
 
     // Slash commands are always client-side — never send to backend
     if (trimmed.startsWith('/')) {
-      handleCommand(trimmed, { activeConversationId, agentId });
+      const feedback = await handleCommand(trimmed, { activeConversationId, agentId });
+      if (feedback) setInfoToast(feedback);
       return;
     }
 
@@ -800,6 +805,8 @@ export function useStreamingChat({
     activeConversationId,
     errorToast,
     setErrorToast,
+    infoToast,
+    setInfoToast,
     externalDraft,
     externalDraftVersion,
     pushExternalDraft,

--- a/src/store/conversationStore.ts
+++ b/src/store/conversationStore.ts
@@ -13,6 +13,11 @@ interface ConversationState {
   messagesOffset: number;
   isLoadingMessages: boolean;
 
+  // Context window data
+  compactedUpToId: number;
+  compactedContext: string;
+  systemPromptTokenCount: number;
+
   loadConversation: (id: number) => Promise<void>;
   loadMoreMessages: () => Promise<void>;
   deleteConversation: (id: number) => Promise<void>;
@@ -20,6 +25,7 @@ interface ConversationState {
   addMessage: (message: Message) => void;
   updateLastMessage: (content: string, thinking?: string, role?: string, name?: string) => void;
   setCurrentConversationId: (id: number) => void;
+  updateCompactionData: (compactedUpToId: number, compactedContext: string) => void;
 }
 
 export const useConversationStore = create<ConversationState>((set, get) => ({
@@ -33,6 +39,11 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
   messagesOffset: 0,
   isLoadingMessages: false,
 
+  // Context window data
+  compactedUpToId: 0,
+  compactedContext: '',
+  systemPromptTokenCount: 0,
+
   loadConversation: async (id: number) => {
     const data = await apiClient.getConversation(id, 20, 0);
 
@@ -44,6 +55,9 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
       hasMoreMessages: data.has_more,
       messagesOffset: data.limit,
       isLoadingMessages: false,
+      compactedUpToId: data.compacted_up_to_id ?? 0,
+      compactedContext: data.compacted_context ?? '',
+      systemPromptTokenCount: data.system_prompt_token_count ?? 0,
     });
   },
 
@@ -92,6 +106,9 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
       hasMoreMessages: false,
       messagesOffset: 0,
       isLoadingMessages: false,
+      compactedUpToId: 0,
+      compactedContext: '',
+      systemPromptTokenCount: 0,
     });
   },
 
@@ -118,5 +135,9 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
 
   setCurrentConversationId: (id: number) => {
     set({ currentConversation: { id, title: '', frame_count: 0, created_at: '', updated_at: '' } });
+  },
+
+  updateCompactionData: (compactedUpToId: number, compactedContext: string) => {
+    set({ compactedUpToId, compactedContext });
   },
 }));

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -6,6 +6,8 @@
  */
 
 import { wsManager } from '../api/websocket';
+import { useConversationStore } from '../store/conversationStore';
+import { storage } from './storage';
 
 export interface CommandContext {
   activeConversationId: number | null;
@@ -25,6 +27,21 @@ const commands: Command[] = [
     execute: (_args, ctx) => {
       if (ctx.activeConversationId) {
         wsManager.send({ type: 'compact_context', conversation_id: ctx.activeConversationId });
+      }
+    },
+  },
+  {
+    name: 'clear',
+    description: 'Clear the current conversation',
+    execute: async (_args, ctx) => {
+      if (ctx.activeConversationId) {
+        const convStore = useConversationStore.getState();
+        await convStore.deleteConversation(ctx.activeConversationId);
+        if (ctx.agentId) {
+          storage.clearAgentConversationId(ctx.agentId);
+        } else {
+          storage.clearAgentConversationId('group');
+        }
       }
     },
   },

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -6,8 +6,6 @@
  */
 
 import { wsManager } from '../api/websocket';
-import { useConversationStore } from '../store/conversationStore';
-import { storage } from './storage';
 
 export interface CommandContext {
   activeConversationId: number | null;
@@ -37,6 +35,8 @@ const commands: Command[] = [
     description: 'Clear the current conversation',
     execute: async (_args, ctx) => {
       if (ctx.activeConversationId) {
+        const { useConversationStore } = await import('../store/conversationStore');
+        const { storage } = await import('./storage');
         const convStore = useConversationStore.getState();
         await convStore.deleteConversation(ctx.activeConversationId);
         if (ctx.agentId) {

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -17,7 +17,7 @@ export interface CommandContext {
 interface Command {
   name: string;
   description: string;
-  execute: (args: string, ctx: CommandContext) => void;
+  execute: (args: string, ctx: CommandContext) => Promise<string> | string;
 }
 
 const commands: Command[] = [
@@ -27,7 +27,9 @@ const commands: Command[] = [
     execute: (_args, ctx) => {
       if (ctx.activeConversationId) {
         wsManager.send({ type: 'compact_context', conversation_id: ctx.activeConversationId });
+        return 'Compacting context...';
       }
+      return 'No active conversation';
     },
   },
   {
@@ -42,27 +44,28 @@ const commands: Command[] = [
         } else {
           storage.clearAgentConversationId('group');
         }
+        return 'Conversation cleared';
       }
+      return 'No active conversation';
     },
   },
 ];
 
 /**
  * Try to handle text as a slash command.
- * Returns true if the text was a command (handled), false otherwise.
+ * Returns feedback message if handled, null if not a command.
  */
-export function handleCommand(text: string, ctx: CommandContext): boolean {
-  if (!text.startsWith('/')) return false;
+export async function handleCommand(text: string, ctx: CommandContext): Promise<string | null> {
+  if (!text.startsWith('/')) return null;
 
   const spaceIdx = text.indexOf(' ');
   const name = (spaceIdx === -1 ? text.slice(1) : text.slice(1, spaceIdx)).toLowerCase();
   const args = spaceIdx === -1 ? '' : text.slice(spaceIdx + 1).trim();
 
   const cmd = commands.find((c) => c.name === name);
-  if (!cmd) return false;
+  if (!cmd) return null;
 
-  cmd.execute(args, ctx);
-  return true;
+  return await cmd.execute(args, ctx);
 }
 
 /** Get all registered commands (for autocomplete/help). */


### PR DESCRIPTION
## Summary
- **Context window display mode**: Toggle between "All" (full history) and "Context" (only messages the LLM sees after compaction watermark) with a collapsible compacted context summary banner
- **Token usage indicator**: Always-visible "used / cap tokens" bar, frontend-calculated from context window messages + compacted context, with live backend count during streaming
- **Slash commands**: `/compact` (compact context), `/clear` (delete conversation) with info toast feedback, autocomplete dropdown, and Enter to auto-select first match
- **Compacted message protection**: Disable resend for compacted messages
- **Bug fixes**: Fix React crash from circular imports in commands, close command dropdown after selection, block all `/`-prefixed messages from backend

## Test plan
- [ ] Load a conversation — token count shows, toggle between All/Context modes
- [ ] Run `/compact` — context view filters old messages, shows summary banner
- [ ] Run `/clear` — conversation cleared with toast feedback
- [ ] Type `/` — dropdown appears, Enter selects first command, dropdown closes
- [ ] Compacted messages don't show resend button
- [ ] During streaming — token count updates live

🤖 Generated with [Claude Code](https://claude.com/claude-code)