### PR TITLE
Add deferred tools UI, tool_status styling, and available_tools allowlist

### DIFF
--- a/electron/appTools.ts
+++ b/electron/appTools.ts
@@ -96,10 +96,10 @@ function getAppToolSchemas(): ToolSchema[] {
             name: { type: 'string', description: 'New display name.' },
             system_prompt: { type: 'string', description: 'New system prompt / personality.' },
             model_name: { type: 'string', description: 'LLM model name (e.g. "gemma3:4b").' },
-            excluded_tools: {
+            available_tools: {
               type: 'array',
               items: { type: 'string' },
-              description: 'List of tool names to exclude.',
+              description: 'Allowlist of tool names (null = all tools available).',
             },
             think: { type: 'boolean', description: 'Enable extended reasoning.' },
             memory_enabled: { type: 'boolean', description: 'Enable memory injection + consolidation.' },

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -146,7 +146,7 @@ export interface Agent {
   system_prompt: string;
   model_name: string | null;
   provider_type: string;
-  excluded_tools: string[] | null;
+  available_tools: string[] | null;
   think: boolean;
   memory: string | null;
   memory_enabled: boolean;
@@ -190,7 +190,7 @@ export interface AgentCreate {
   system_prompt?: string;
   model_name: string;
   provider_type?: string;
-  excluded_tools?: string[];
+  available_tools?: string[];
   think?: boolean;
   persona_id?: number;
   use_deferred_tools?: boolean;
@@ -201,7 +201,7 @@ export interface AgentUpdate {
   system_prompt?: string;
   model_name?: string;
   provider_type?: string;
-  excluded_tools?: string[];
+  available_tools?: string[];
   think?: boolean;
   memory?: string;
   memory_enabled?: boolean;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -30,6 +30,7 @@ export interface Message {
   model_name?: string; // LLM model that generated this message
   provider_type?: string; // LLM provider (ollama, gemini)
   tool_args?: Record<string, unknown>; // Tool input arguments (for tool role messages)
+  tool_status?: string; // "success" | "error" | "denied" (from backend)
   queued?: boolean; // Queued message waiting to be processed
 }
 
@@ -151,6 +152,7 @@ export interface Agent {
   memory_enabled: boolean;
   enabled: boolean;
   is_system: boolean;
+  use_deferred_tools: boolean;
   persona_id: number | null;
   persona: Persona | null;
 }
@@ -191,6 +193,7 @@ export interface AgentCreate {
   excluded_tools?: string[];
   think?: boolean;
   persona_id?: number;
+  use_deferred_tools?: boolean;
 }
 
 export interface AgentUpdate {
@@ -203,6 +206,7 @@ export interface AgentUpdate {
   memory?: string;
   memory_enabled?: boolean;
   persona_id?: number | null;
+  use_deferred_tools?: boolean;
 }
 
 // MCP Server types

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -68,6 +68,7 @@ export interface StreamChunkEvent extends BaseEvent {
   model_name: string | null;
   provider_type: string | null;
   tool_args: Record<string, unknown> | null;
+  tool_status: string | null;  // "success" | "error" | "denied"
   conversation_id: number;
   frame_id: number;
   images: string[] | null;

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -234,16 +234,15 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     return messages;
   }, [messages, displayMode, compactedUpToId]);
 
-  // Token count: backend value during streaming, frontend estimate at rest
-  const estimatedTokens = useMemo(() => {
+  // Token count: frontend estimate from persisted messages + live streaming content
+  const tokenCount = useMemo(() => {
     const contextMsgs = messages.filter(m => (m.id ?? Infinity) > compactedUpToId);
     const wc = (t: string | undefined) => t ? t.split(/\s+/).length : 0;
     const msgWords = contextMsgs.reduce((n, m) => n + wc(m.content) + wc(m.thinking), 0);
+    const streamWords = wc(streaming.streamingContent) + wc(streaming.streamingThinking);
     const contextWords = wc(compactedContext);
-    return Math.round((msgWords + contextWords) * 1.3);
-  }, [messages, compactedUpToId, compactedContext]);
-
-  const tokenCount = estimatedTokens;
+    return Math.round((msgWords + streamWords + contextWords) * 1.3);
+  }, [messages, compactedUpToId, compactedContext, streaming.streamingContent, streaming.streamingThinking]);
 
   // Message rendering
   const messageElements = useMemo(() => {

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -209,8 +209,7 @@ const MessageBubbleComponent: React.FC<MessageBubbleProps> = ({
     }
     switch (message.role) {
       case 'tool': {
-        const lc = message.content.toLowerCase();
-        const isError = message.content.startsWith('Error:') || lc.includes('error') || lc.includes('rejected') || lc.includes('denied') || lc.includes('not available') || lc.includes('not found') || lc.includes('failed');
+        const isError = message.tool_status === 'error' || message.tool_status === 'denied';
         if (isError) {
           return {
             bg: isDark ? '#2A0000' : '#FFF0F0',

--- a/src/components/settings/AgentEditDialog.tsx
+++ b/src/components/settings/AgentEditDialog.tsx
@@ -45,6 +45,7 @@ interface AgentFormData {
   memory: string;
   memory_enabled: boolean;
   persona_id: number | null;
+  use_deferred_tools: boolean;
 }
 
 interface AgentEditDialogProps {
@@ -254,6 +255,17 @@ export const AgentEditDialog: React.FC<AgentEditDialogProps> = ({
                 <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
                   Uncheck tools this agent should not use.
                 </Typography>
+              </Box>
+              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2, p: 2, borderRadius: 2, backgroundColor: 'background.default', border: '1px solid', borderColor: 'divider' }}>
+                <Box>
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    Deferred Tools
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    Only send tool names to the model. It discovers schemas on demand, preserving KV cache.
+                  </Typography>
+                </Box>
+                <Switch checked={formData.use_deferred_tools} onChange={(e) => setFormData({ ...formData, use_deferred_tools: e.target.checked })} />
               </Box>
               <Box sx={{ p: 2, borderRadius: 2, backgroundColor: 'background.default', border: '1px solid', borderColor: 'divider' }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2 }}>

--- a/src/components/settings/AgentEditDialog.tsx
+++ b/src/components/settings/AgentEditDialog.tsx
@@ -41,7 +41,7 @@ interface AgentFormData {
   system_prompt: string;
   model_name: string;
   think: boolean;
-  excluded_tools: string[];
+  available_tools: string[] | null;
   memory: string;
   memory_enabled: boolean;
   persona_id: number | null;
@@ -249,8 +249,8 @@ export const AgentEditDialog: React.FC<AgentEditDialogProps> = ({
               <Box>
                 <ToolGroupChecklist
                   groups={toolGroups}
-                  excludedTools={formData.excluded_tools}
-                  onChange={(excluded) => setFormData({ ...formData, excluded_tools: excluded })}
+                  enabledTools={formData.available_tools}
+                  onChange={(enabled) => setFormData({ ...formData, available_tools: enabled })}
                 />
                 <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
                   Uncheck tools this agent should not use.

--- a/src/components/settings/AgentsSection.tsx
+++ b/src/components/settings/AgentsSection.tsx
@@ -56,6 +56,7 @@ interface AgentFormData {
   memory: string;
   memory_enabled: boolean;
   persona_id: number | null;
+  use_deferred_tools: boolean;
 }
 
 export const AgentsSection: React.FC = () => {
@@ -84,6 +85,7 @@ export const AgentsSection: React.FC = () => {
     memory: '',
     memory_enabled: true,
     persona_id: null,
+    use_deferred_tools: false,
   });
   const [personas, setPersonas] = useState<Persona[]>([]);
 
@@ -176,6 +178,7 @@ export const AgentsSection: React.FC = () => {
         think: formData.think,
         excluded_tools: formData.excluded_tools.length > 0 ? formData.excluded_tools : undefined,
         persona_id: formData.persona_id || undefined,
+        use_deferred_tools: formData.use_deferred_tools || undefined,
       };
 
       const newAgent = await apiClient.createAgent(createData);
@@ -206,6 +209,7 @@ export const AgentsSection: React.FC = () => {
         memory: formData.memory !== (selectedAgent.memory || '') ? formData.memory : undefined,
         memory_enabled: formData.memory_enabled !== selectedAgent.memory_enabled ? formData.memory_enabled : undefined,
         persona_id: formData.persona_id !== selectedAgent.persona_id ? formData.persona_id : undefined,
+        use_deferred_tools: formData.use_deferred_tools !== selectedAgent.use_deferred_tools ? formData.use_deferred_tools : undefined,
       };
 
       // Only send fields that changed
@@ -279,6 +283,7 @@ export const AgentsSection: React.FC = () => {
       memory: '',
       memory_enabled: true,
       persona_id: null,
+      use_deferred_tools: false,
     });
     setSelectedAgent(null);
     setIsPromptEditorExpanded(false);
@@ -295,6 +300,7 @@ export const AgentsSection: React.FC = () => {
       memory: agent.memory || '',
       memory_enabled: agent.memory_enabled,
       persona_id: agent.persona_id || null,
+      use_deferred_tools: agent.use_deferred_tools ?? false,
     });
     setIsPromptEditorExpanded(false);
     setEditDialogOpen(true);

--- a/src/components/settings/AgentsSection.tsx
+++ b/src/components/settings/AgentsSection.tsx
@@ -52,7 +52,7 @@ interface AgentFormData {
   system_prompt: string;
   model_name: string;
   think: boolean;
-  excluded_tools: string[];
+  available_tools: string[] | null;
   memory: string;
   memory_enabled: boolean;
   persona_id: number | null;
@@ -81,7 +81,7 @@ export const AgentsSection: React.FC = () => {
     system_prompt: '',
     model_name: '',
     think: false,
-    excluded_tools: [],
+    available_tools: null,
     memory: '',
     memory_enabled: true,
     persona_id: null,
@@ -176,7 +176,7 @@ export const AgentsSection: React.FC = () => {
         model_name: modelName,
         provider_type: provider,
         think: formData.think,
-        excluded_tools: formData.excluded_tools.length > 0 ? formData.excluded_tools : undefined,
+        available_tools: formData.available_tools ?? undefined,
         persona_id: formData.persona_id || undefined,
         use_deferred_tools: formData.use_deferred_tools || undefined,
       };
@@ -197,7 +197,7 @@ export const AgentsSection: React.FC = () => {
     if (!selectedAgent) return;
 
     try {
-      const toolsChanged = JSON.stringify(formData.excluded_tools) !== JSON.stringify(selectedAgent.excluded_tools || []);
+      const toolsChanged = JSON.stringify(formData.available_tools) !== JSON.stringify(selectedAgent.available_tools ?? null);
       const normalizedModelName = formData.model_name.trim();
       const updateData: AgentUpdate = {
         name: formData.name !== selectedAgent.name ? formData.name : undefined,
@@ -205,7 +205,7 @@ export const AgentsSection: React.FC = () => {
         model_name: normalizedModelName !== (selectedAgent.model_name || '') ? normalizedModelName : undefined,
         provider_type: models.find(m => m.name === normalizedModelName)?.provider || 'ollama',
         think: formData.think !== selectedAgent.think ? formData.think : undefined,
-        excluded_tools: toolsChanged ? formData.excluded_tools : undefined,
+        available_tools: toolsChanged ? formData.available_tools : undefined,
         memory: formData.memory !== (selectedAgent.memory || '') ? formData.memory : undefined,
         memory_enabled: formData.memory_enabled !== selectedAgent.memory_enabled ? formData.memory_enabled : undefined,
         persona_id: formData.persona_id !== selectedAgent.persona_id ? formData.persona_id : undefined,
@@ -279,7 +279,7 @@ export const AgentsSection: React.FC = () => {
       system_prompt: '',
       model_name: '',
       think: false,
-      excluded_tools: [],
+      available_tools: null,
       memory: '',
       memory_enabled: true,
       persona_id: null,
@@ -296,7 +296,7 @@ export const AgentsSection: React.FC = () => {
       system_prompt: agent.system_prompt || '',
       model_name: agent.model_name || '',
       think: agent.think,
-      excluded_tools: agent.excluded_tools || [],
+      available_tools: agent.available_tools ?? null,
       memory: agent.memory || '',
       memory_enabled: agent.memory_enabled,
       persona_id: agent.persona_id || null,
@@ -600,8 +600,8 @@ export const AgentsSection: React.FC = () => {
               <Typography variant="body2" sx={{ mb: 1, fontWeight: 500 }}>Enabled Tools</Typography>
               <ToolGroupChecklist
                 groups={toolGroups}
-                excludedTools={formData.excluded_tools}
-                onChange={(excluded) => setFormData({ ...formData, excluded_tools: excluded })}
+                enabledTools={formData.available_tools}
+                onChange={(enabled) => setFormData({ ...formData, available_tools: enabled })}
               />
               <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
                 All tools enabled by default. Uncheck to disable for this agent.

--- a/src/components/settings/ToolGroupChecklist.tsx
+++ b/src/components/settings/ToolGroupChecklist.tsx
@@ -94,13 +94,15 @@ export function buildToolGroups(tools: Tool[], mcpServerMap: Record<string, stri
 }
 
 // Grouped tool checklist component
+// enabledTools: allowlist of tool names (null = all enabled)
 export const ToolGroupChecklist: React.FC<{
   groups: ToolGroup[];
-  excludedTools: string[];
-  onChange: (excludedTools: string[]) => void;
-}> = ({ groups, excludedTools, onChange }) => {
+  enabledTools: string[] | null;
+  onChange: (enabledTools: string[] | null) => void;
+}> = ({ groups, enabledTools, onChange }) => {
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
-  const excludedSet = useMemo(() => new Set(excludedTools), [excludedTools]);
+  const allToolNames = useMemo(() => groups.flatMap(g => g.tools.map(t => t.function.name)), [groups]);
+  const enabledSet = useMemo(() => enabledTools ? new Set(enabledTools) : new Set(allToolNames), [enabledTools, allToolNames]);
 
   const toggleExpand = (groupName: string) => {
     setExpandedGroups(prev => {
@@ -112,30 +114,33 @@ export const ToolGroupChecklist: React.FC<{
   };
 
   const toggleTool = (toolName: string) => {
-    if (excludedSet.has(toolName)) {
-      onChange(excludedTools.filter(t => t !== toolName));
+    const current = new Set(enabledSet);
+    if (current.has(toolName)) {
+      current.delete(toolName);
     } else {
-      onChange([...excludedTools, toolName]);
+      current.add(toolName);
     }
+    // If all enabled, return null (= all)
+    onChange(current.size === allToolNames.length ? null : [...current]);
   };
 
   const toggleGroup = (group: ToolGroup) => {
     const toolNames = group.tools.map(t => t.function.name);
-    const allEnabled = toolNames.every(n => !excludedSet.has(n));
+    const allEnabled = toolNames.every(n => enabledSet.has(n));
+    const current = new Set(enabledSet);
     if (allEnabled) {
-      // Disable all in group
-      onChange([...excludedTools, ...toolNames.filter(n => !excludedSet.has(n))]);
+      toolNames.forEach(n => current.delete(n));
     } else {
-      // Enable all in group
-      onChange(excludedTools.filter(t => !toolNames.includes(t)));
+      toolNames.forEach(n => current.add(n));
     }
+    onChange(current.size === allToolNames.length ? null : [...current]);
   };
 
   return (
     <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, overflow: 'hidden' }}>
       {groups.map((group) => {
         const toolNames = group.tools.map(t => t.function.name);
-        const enabledCount = toolNames.filter(n => !excludedSet.has(n)).length;
+        const enabledCount = toolNames.filter(n => enabledSet.has(n)).length;
         const allEnabled = enabledCount === toolNames.length;
         const noneEnabled = enabledCount === 0;
         const isExpanded = expandedGroups.has(group.name);
@@ -174,7 +179,7 @@ export const ToolGroupChecklist: React.FC<{
             <Collapse in={isExpanded}>
               {group.tools.map((tool) => {
                 const name = tool.function.name;
-                const enabled = !excludedSet.has(name);
+                const enabled = enabledSet.has(name);
                 return (
                   <Box
                     key={name}

--- a/src/hooks/useStreamingChat.ts
+++ b/src/hooks/useStreamingChat.ts
@@ -294,6 +294,7 @@ export function useStreamingChat({
           model_name: event.model_name || undefined,
           provider_type: event.provider_type || undefined,
           tool_args: event.tool_args || undefined,
+          tool_status: event.tool_status || undefined,
         });
         return updated;
       });
@@ -337,6 +338,7 @@ export function useStreamingChat({
               model_name: event.model_name || undefined,
               provider_type: event.provider_type || undefined,
               tool_args: event.tool_args || undefined,
+              tool_status: event.tool_status || undefined,
             };
           }
           return updated;
@@ -353,6 +355,7 @@ export function useStreamingChat({
           model_name: event.model_name || undefined,
           provider_type: event.provider_type || undefined,
           tool_args: event.tool_args || undefined,
+          tool_status: event.tool_status || undefined,
         }]);
       }
 

--- a/src/services/appToolsHandler.ts
+++ b/src/services/appToolsHandler.ts
@@ -45,7 +45,7 @@ async function handleGetAgents(): Promise<ToolResult> {
       preferred_name: a.persona.preferred_name,
       trigger_word: a.persona.trigger_word,
     } : null,
-    excluded_tools: a.excluded_tools,
+    available_tools: a.available_tools,
   })));
 }
 
@@ -71,7 +71,7 @@ async function handleUpdateAgent(args: Record<string, unknown>): Promise<ToolRes
   if (!agentId) return err('agent_id is required.');
 
   const update: Record<string, unknown> = {};
-  for (const key of ['name', 'system_prompt', 'model_name', 'excluded_tools', 'think', 'memory_enabled', 'persona_id']) {
+  for (const key of ['name', 'system_prompt', 'model_name', 'available_tools', 'think', 'memory_enabled', 'persona_id']) {
     if (args[key] !== undefined) update[key] = args[key];
   }
 


### PR DESCRIPTION
## Summary
- **Deferred tools toggle** in agent edit dialog (Tools & Memory section)
- **tool_status styling**: Use backend `tool_status` field for red/green tool result bubbles instead of keyword matching on content
- **available_tools allowlist**: Renamed `excluded_tools` → `available_tools`. `ToolGroupChecklist` now uses allowlist semantics (`null` = all enabled)
- **Live token count**: Fixed streaming token counter by reading `streamingContent` (rAF-updated) instead of `streamingMessages`

Companion to Khoality-dev/KurisuAssistant#73

## Test plan
- [ ] Verify deferred tools toggle enables/disables per agent
- [ ] Verify tool checklist shows correct state and saves as allowlist
- [ ] Verify failed tools show red, successful tools show green
- [ ] Verify token count updates live during streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)