### PR TITLE
ASR language-to-model routing with auto-detect

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -377,11 +377,12 @@ class APIClient {
    */
   async transcribe(
     audio: ArrayBuffer,
-    options?: { language?: string; mode?: string },
+    options?: { language?: string; mode?: string; model?: string },
   ): Promise<{ text: string; language: string }> {
     const params: Record<string, string> = {};
     if (options?.language) params.language = options.language;
     if (options?.mode) params.mode = options.mode;
+    if (options?.model) params.model = options.model;
 
     const response = await this.client.post<{ text: string; language: string }>('/asr', audio, {
       headers: { ...this.getHeaders(), 'Content-Type': 'application/octet-stream' },
@@ -389,6 +390,22 @@ class APIClient {
       timeout: 30000,
     });
     return response.data;
+  }
+
+  async detectLanguage(audio: ArrayBuffer): Promise<{ language: string }> {
+    const response = await this.client.post<{ language: string }>('/asr/detect-language', audio, {
+      headers: { ...this.getHeaders(), 'Content-Type': 'application/octet-stream' },
+      timeout: 15000,
+    });
+    return response.data;
+  }
+
+  async getASRModels(): Promise<Array<{ id: string; name: string; size_mb: number | null; loaded: boolean }>> {
+    const response = await this.client.get<{ data: Array<{ id: string; name: string; size_mb: number | null; loaded: boolean }> }>(
+      '/asr/models',
+      { headers: this.getHeaders() },
+    );
+    return response.data.data || [];
   }
 
   // Agent Methods

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -377,12 +377,13 @@ class APIClient {
    */
   async transcribe(
     audio: ArrayBuffer,
-    options?: { language?: string; mode?: string; model?: string },
+    options?: { language?: string; mode?: string; model?: string; initial_prompt?: string },
   ): Promise<{ text: string; language: string }> {
     const params: Record<string, string> = {};
     if (options?.language) params.language = options.language;
     if (options?.mode) params.mode = options.mode;
     if (options?.model) params.model = options.model;
+    if (options?.initial_prompt) params.initial_prompt = options.initial_prompt;
 
     const response = await this.client.post<{ text: string; language: string }>('/asr', audio, {
       headers: { ...this.getHeaders(), 'Content-Type': 'application/octet-stream' },

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -393,9 +393,13 @@ class APIClient {
     return response.data;
   }
 
-  async detectLanguage(audio: ArrayBuffer): Promise<{ language: string }> {
+  async detectLanguage(audio: ArrayBuffer, options?: { languages?: string[] }): Promise<{ language: string }> {
+    const params: Record<string, string> = {};
+    if (options?.languages?.length) params.languages = options.languages.join(',');
+
     const response = await this.client.post<{ language: string }>('/asr/detect-language', audio, {
       headers: { ...this.getHeaders(), 'Content-Type': 'application/octet-stream' },
+      params,
       timeout: 15000,
     });
     return response.data;

--- a/src/components/settings/TTSSection.tsx
+++ b/src/components/settings/TTSSection.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import {
   Box,
   Typography,
-  TextField,
   FormControl,
   InputLabel,
   Select,
@@ -10,30 +9,68 @@ import {
   FormControlLabel,
   Switch,
   Divider,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Button,
+  SelectChangeEvent,
 } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AddIcon from '@mui/icons-material/Add';
 import { useTTS } from '../../hooks/useTTS';
 import { storage } from '../../utils/storage';
+import { apiClient } from '../../api/client';
+
+interface ModelEntry {
+  id: string;
+  name: string;
+}
+
+const COMMON_LANGUAGES = [
+  { code: 'en', label: 'English' },
+  { code: 'vi', label: 'Vietnamese' },
+  { code: 'ja', label: 'Japanese' },
+  { code: 'zh', label: 'Chinese' },
+  { code: 'ko', label: 'Korean' },
+  { code: 'fr', label: 'French' },
+  { code: 'de', label: 'German' },
+  { code: 'es', label: 'Spanish' },
+  { code: 'ru', label: 'Russian' },
+  { code: 'pt', label: 'Portuguese' },
+  { code: 'th', label: 'Thai' },
+  { code: 'ar', label: 'Arabic' },
+];
 
 export const TTSSection: React.FC = () => {
   const { backends, loadBackends } = useTTS();
 
-  // ASR settings -- auto-saved to localStorage on change
+  // ASR settings
   const [asrLanguage, setAsrLanguageState] = useState(storage.getASRLanguage() || '');
+  const [modelMap, setModelMapState] = useState(storage.getASRModelMap());
+  const [availableModels, setAvailableModels] = useState<ModelEntry[]>([]);
+
   const setAsrLanguage = (v: string) => {
     setAsrLanguageState(v);
     if (v) storage.setASRLanguage(v);
     else storage.clearASRLanguage();
   };
 
-  // TTS settings -- auto-saved to localStorage on change
+  const setModelMap = (map: Array<{ language: string; model: string }>) => {
+    setModelMapState(map);
+    storage.setASRModelMap(map);
+  };
+
+  const handleLanguageChange = (e: SelectChangeEvent) => setAsrLanguage(e.target.value);
+
+  // TTS settings
   const [ttsBackend, setTtsBackendState] = useState(storage.getTTSBackend() || 'vixtts');
   const [ttsAutoPlay, setTtsAutoPlayState] = useState(storage.getTTSAutoPlay());
-
-  // viXTTS emotion settings
   const [ttsEmotionAlpha, setTtsEmotionAlphaState] = useState(storage.getTTSEmotionAlpha());
   const [ttsUseEmotionText, setTtsUseEmotionTextState] = useState(storage.getTTSUseEmotionText());
 
-  // Auto-save wrappers
   const setTtsBackend = (v: string) => { setTtsBackendState(v); storage.setTTSBackend(v); };
   const setTtsAutoPlay = (v: boolean) => { setTtsAutoPlayState(v); storage.setTTSAutoPlay(v); };
   const setTtsEmotionAlpha = (v: number) => { setTtsEmotionAlphaState(v); storage.setTTSEmotionAlpha(v); };
@@ -41,22 +78,135 @@ export const TTSSection: React.FC = () => {
 
   useEffect(() => {
     loadBackends();
+    apiClient.getASRModels()
+      .then((models) => setAvailableModels(models.map((m) => ({ id: m.id, name: m.name }))))
+      .catch(() => {});
   }, [loadBackends]);
+
+  const addMapping = () => {
+    setModelMap([...modelMap, { language: '', model: '' }]);
+  };
+
+  const updateMapping = (index: number, field: 'language' | 'model', value: string) => {
+    const updated = [...modelMap];
+    updated[index] = { ...updated[index], [field]: value };
+    setModelMap(updated);
+  };
+
+  const removeMapping = (index: number) => {
+    setModelMap(modelMap.filter((_entry, i) => i !== index));
+  };
 
   return (
     <Box sx={{ maxWidth: 700 }}>
       <Typography variant="h3" sx={{ mb: 3 }}>TTS & ASR</Typography>
 
-      {/* ASR Language */}
+      {/* ASR Settings */}
       <Box sx={{ mb: 3 }}>
-        <TextField
-          label="ASR Language"
-          value={asrLanguage}
-          onChange={(e) => setAsrLanguage(e.target.value)}
-          fullWidth
-          placeholder="Auto-detect"
-          helperText="ISO 639-1 code (en, ja, zh, vi). Empty = auto-detect from first transcription."
-        />
+        <FormControl fullWidth size="small">
+          <InputLabel>ASR Language</InputLabel>
+          <Select
+            value={asrLanguage}
+            label="ASR Language"
+            onChange={handleLanguageChange}
+          >
+            <MenuItem value="">
+              <em>Auto-detect</em>
+            </MenuItem>
+            <MenuItem value="auto-route">
+              <em>Auto (detect &amp; route to model)</em>
+            </MenuItem>
+            {COMMON_LANGUAGES.map((lang) => (
+              <MenuItem key={lang.code} value={lang.code}>
+                {lang.label} ({lang.code})
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+          Auto-detect: let the model guess. Auto (detect &amp; route): detect language first, then use the mapped model for that language.
+        </Typography>
+      </Box>
+
+      {/* Language → Model Mapping */}
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>
+          Language → Model Mapping
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1.5 }}>
+          Assign a specific ASR model per language. When a language matches, its mapped model is used for transcription.
+        </Typography>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Language</TableCell>
+              <TableCell>Model</TableCell>
+              <TableCell width={48}></TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {modelMap.map((entry, i) => (
+              <TableRow key={i}>
+                <TableCell sx={{ py: 0.5 }}>
+                  <FormControl fullWidth size="small" variant="standard">
+                    <Select
+                      value={entry.language}
+                      onChange={(e) => updateMapping(i, 'language', e.target.value)}
+                      displayEmpty
+                    >
+                      <MenuItem value="">
+                        <em>Select...</em>
+                      </MenuItem>
+                      {COMMON_LANGUAGES.map((lang) => (
+                        <MenuItem key={lang.code} value={lang.code}>
+                          {lang.label} ({lang.code})
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                </TableCell>
+                <TableCell sx={{ py: 0.5 }}>
+                  <FormControl fullWidth size="small" variant="standard">
+                    <Select
+                      value={entry.model}
+                      onChange={(e) => updateMapping(i, 'model', e.target.value)}
+                      displayEmpty
+                    >
+                      <MenuItem value="">
+                        <em>Default</em>
+                      </MenuItem>
+                      {availableModels.map((m) => (
+                        <MenuItem key={m.id} value={m.name}>
+                          {m.name}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                </TableCell>
+                <TableCell sx={{ py: 0.5 }}>
+                  <IconButton size="small" onClick={() => removeMapping(i)}>
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+            {modelMap.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={3} sx={{ color: 'text.secondary', textAlign: 'center' }}>
+                  No mappings. All languages use the default model.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+        <Button
+          size="small"
+          startIcon={<AddIcon />}
+          onClick={addMapping}
+          sx={{ mt: 1 }}
+        >
+          Add mapping
+        </Button>
       </Box>
 
       <Divider sx={{ mb: 3 }} />
@@ -102,7 +252,6 @@ export const TTSSection: React.FC = () => {
             Emotion Controls (viXTTS)
           </Typography>
 
-          {/* Emotion Strength (Alpha) */}
           <Box sx={{ mb: 3 }}>
             <Typography gutterBottom>
               Emotion Strength: {ttsEmotionAlpha.toFixed(1)}
@@ -126,7 +275,6 @@ export const TTSSection: React.FC = () => {
             </Box>
           </Box>
 
-          {/* Use Emotion from Text */}
           <Box sx={{ mb: 4 }}>
             <FormControlLabel
               control={

--- a/src/components/settings/TTSSection.tsx
+++ b/src/components/settings/TTSSection.tsx
@@ -51,7 +51,6 @@ export const TTSSection: React.FC = () => {
   const [asrMode, setAsrModeState] = useState(storage.getASRMode());
   const [asrLanguage, setAsrLanguageState] = useState(storage.getASRLanguage() || '');
   const [asrFixedModel, setAsrFixedModelState] = useState(storage.getASRFixedModel());
-  const [asrFallbackModel, setAsrFallbackModelState] = useState(storage.getASRFallbackModel());
   const [modelMap, setModelMapState] = useState(storage.getASRModelMap());
   const [availableModels, setAvailableModels] = useState<ModelEntry[]>([]);
 
@@ -71,10 +70,6 @@ export const TTSSection: React.FC = () => {
     storage.setASRFixedModel(v);
   };
 
-  const setAsrFallbackModel = (v: string) => {
-    setAsrFallbackModelState(v);
-    storage.setASRFallbackModel(v);
-  };
 
   const setModelMap = (map: Array<{ language: string; model: string }>) => {
     setModelMapState(map);
@@ -240,26 +235,6 @@ export const TTSSection: React.FC = () => {
           >
             Add mapping
           </Button>
-          <FormControl fullWidth size="small" sx={{ mt: 2 }}>
-            <InputLabel>Fallback model (other languages)</InputLabel>
-            <Select
-              value={asrFallbackModel}
-              label="Fallback model (other languages)"
-              onChange={(e: SelectChangeEvent) => setAsrFallbackModel(e.target.value)}
-            >
-              <MenuItem value="">
-                <em>Default (server)</em>
-              </MenuItem>
-              {availableModels.map((m) => (
-                <MenuItem key={m.id} value={m.name}>
-                  {m.name}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-            Used when the detected language doesn't match any mapping above.
-          </Typography>
         </Box>
       )}
 

--- a/src/components/settings/TTSSection.tsx
+++ b/src/components/settings/TTSSection.tsx
@@ -48,9 +48,16 @@ export const TTSSection: React.FC = () => {
   const { backends, loadBackends } = useTTS();
 
   // ASR settings
+  const [asrMode, setAsrModeState] = useState(storage.getASRMode());
   const [asrLanguage, setAsrLanguageState] = useState(storage.getASRLanguage() || '');
+  const [asrFixedModel, setAsrFixedModelState] = useState(storage.getASRFixedModel());
   const [modelMap, setModelMapState] = useState(storage.getASRModelMap());
   const [availableModels, setAvailableModels] = useState<ModelEntry[]>([]);
+
+  const setAsrMode = (v: 'fixed' | 'routing') => {
+    setAsrModeState(v);
+    storage.setASRMode(v);
+  };
 
   const setAsrLanguage = (v: string) => {
     setAsrLanguageState(v);
@@ -58,12 +65,15 @@ export const TTSSection: React.FC = () => {
     else storage.clearASRLanguage();
   };
 
+  const setAsrFixedModel = (v: string) => {
+    setAsrFixedModelState(v);
+    storage.setASRFixedModel(v);
+  };
+
   const setModelMap = (map: Array<{ language: string; model: string }>) => {
     setModelMapState(map);
     storage.setASRModelMap(map);
   };
-
-  const handleLanguageChange = (e: SelectChangeEvent) => setAsrLanguage(e.target.value);
 
   // TTS settings
   const [ttsBackend, setTtsBackendState] = useState(storage.getTTSBackend() || 'vixtts');
@@ -101,113 +111,131 @@ export const TTSSection: React.FC = () => {
     <Box sx={{ maxWidth: 700 }}>
       <Typography variant="h3" sx={{ mb: 3 }}>TTS & ASR</Typography>
 
-      {/* ASR Settings */}
+      {/* ASR Mode */}
       <Box sx={{ mb: 3 }}>
         <FormControl fullWidth size="small">
-          <InputLabel>ASR Language</InputLabel>
+          <InputLabel>ASR Mode</InputLabel>
           <Select
-            value={asrLanguage}
-            label="ASR Language"
-            onChange={handleLanguageChange}
+            value={asrMode}
+            label="ASR Mode"
+            onChange={(e: SelectChangeEvent) => setAsrMode(e.target.value as 'fixed' | 'routing')}
           >
-            <MenuItem value="">
-              <em>Auto-detect</em>
-            </MenuItem>
-            <MenuItem value="auto-route">
-              <em>Auto (detect &amp; route to model)</em>
-            </MenuItem>
-            {COMMON_LANGUAGES.map((lang) => (
-              <MenuItem key={lang.code} value={lang.code}>
-                {lang.label} ({lang.code})
-              </MenuItem>
-            ))}
+            <MenuItem value="fixed">Fixed model</MenuItem>
+            <MenuItem value="routing">Auto routing</MenuItem>
           </Select>
         </FormControl>
         <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-          Auto-detect: let the model guess. Auto (detect &amp; route): detect language first, then use the mapped model for that language.
+          {asrMode === 'fixed'
+            ? 'Use one model for all transcription.'
+            : 'Detect language first, then route to the best model for that language.'}
         </Typography>
       </Box>
 
-      {/* Language → Model Mapping — only shown for auto-route */}
-      {asrLanguage === 'auto-route' && <Box sx={{ mb: 3 }}>
-        <Typography variant="subtitle2" sx={{ mb: 1 }}>
-          Language → Model Mapping
-        </Typography>
-        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1.5 }}>
-          Assign a specific ASR model per language. When a language matches, its mapped model is used for transcription.
-        </Typography>
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>Language</TableCell>
-              <TableCell>Model</TableCell>
-              <TableCell width={48}></TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {modelMap.map((entry, i) => (
-              <TableRow key={i}>
-                <TableCell sx={{ py: 0.5 }}>
-                  <FormControl fullWidth size="small" variant="standard">
-                    <Select
-                      value={entry.language}
-                      onChange={(e) => updateMapping(i, 'language', e.target.value)}
-                      displayEmpty
-                    >
-                      <MenuItem value="">
-                        <em>Select...</em>
-                      </MenuItem>
-                      {COMMON_LANGUAGES.map((lang) => (
-                        <MenuItem key={lang.code} value={lang.code}>
-                          {lang.label} ({lang.code})
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                </TableCell>
-                <TableCell sx={{ py: 0.5 }}>
-                  <FormControl fullWidth size="small" variant="standard">
-                    <Select
-                      value={entry.model}
-                      onChange={(e) => updateMapping(i, 'model', e.target.value)}
-                      displayEmpty
-                    >
-                      <MenuItem value="">
-                        <em>Default</em>
-                      </MenuItem>
-                      {availableModels.map((m) => (
-                        <MenuItem key={m.id} value={m.name}>
-                          {m.name}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                </TableCell>
-                <TableCell sx={{ py: 0.5 }}>
-                  <IconButton size="small" onClick={() => removeMapping(i)}>
-                    <DeleteIcon fontSize="small" />
-                  </IconButton>
-                </TableCell>
-              </TableRow>
-            ))}
-            {modelMap.length === 0 && (
+      {/* Fixed model settings */}
+      {asrMode === 'fixed' && (
+        <Box sx={{ mb: 3 }}>
+          <FormControl fullWidth size="small">
+            <InputLabel>Model</InputLabel>
+            <Select
+              value={asrFixedModel}
+              label="Model"
+              onChange={(e: SelectChangeEvent) => setAsrFixedModel(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>Default (server)</em>
+              </MenuItem>
+              {availableModels.map((m) => (
+                <MenuItem key={m.id} value={m.name}>
+                  {m.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Box>
+      )}
+
+      {/* Auto routing settings */}
+      {asrMode === 'routing' && (
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Language → Model Mapping
+          </Typography>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1.5 }}>
+            Each language routes to a specific model. Unmatched languages use the server default.
+          </Typography>
+          <Table size="small">
+            <TableHead>
               <TableRow>
-                <TableCell colSpan={3} sx={{ color: 'text.secondary', textAlign: 'center' }}>
-                  No mappings. All languages use the default model.
-                </TableCell>
+                <TableCell>Language</TableCell>
+                <TableCell>Model</TableCell>
+                <TableCell width={48}></TableCell>
               </TableRow>
-            )}
-          </TableBody>
-        </Table>
-        <Button
-          size="small"
-          startIcon={<AddIcon />}
-          onClick={addMapping}
-          sx={{ mt: 1 }}
-        >
-          Add mapping
-        </Button>
-      </Box>}
+            </TableHead>
+            <TableBody>
+              {modelMap.map((entry, i) => (
+                <TableRow key={i}>
+                  <TableCell sx={{ py: 0.5 }}>
+                    <FormControl fullWidth size="small" variant="standard">
+                      <Select
+                        value={entry.language}
+                        onChange={(e) => updateMapping(i, 'language', e.target.value)}
+                        displayEmpty
+                      >
+                        <MenuItem value="">
+                          <em>Select...</em>
+                        </MenuItem>
+                        {COMMON_LANGUAGES.map((lang) => (
+                          <MenuItem key={lang.code} value={lang.code}>
+                            {lang.label} ({lang.code})
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </TableCell>
+                  <TableCell sx={{ py: 0.5 }}>
+                    <FormControl fullWidth size="small" variant="standard">
+                      <Select
+                        value={entry.model}
+                        onChange={(e) => updateMapping(i, 'model', e.target.value)}
+                        displayEmpty
+                      >
+                        <MenuItem value="">
+                          <em>Default</em>
+                        </MenuItem>
+                        {availableModels.map((m) => (
+                          <MenuItem key={m.id} value={m.name}>
+                            {m.name}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </TableCell>
+                  <TableCell sx={{ py: 0.5 }}>
+                    <IconButton size="small" onClick={() => removeMapping(i)}>
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {modelMap.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={3} sx={{ color: 'text.secondary', textAlign: 'center' }}>
+                    No mappings configured.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+          <Button
+            size="small"
+            startIcon={<AddIcon />}
+            onClick={addMapping}
+            sx={{ mt: 1 }}
+          >
+            Add mapping
+          </Button>
+        </Box>
+      )}
 
       <Divider sx={{ mb: 3 }} />
 

--- a/src/components/settings/TTSSection.tsx
+++ b/src/components/settings/TTSSection.tsx
@@ -51,6 +51,7 @@ export const TTSSection: React.FC = () => {
   const [asrMode, setAsrModeState] = useState(storage.getASRMode());
   const [asrLanguage, setAsrLanguageState] = useState(storage.getASRLanguage() || '');
   const [asrFixedModel, setAsrFixedModelState] = useState(storage.getASRFixedModel());
+  const [asrFallbackModel, setAsrFallbackModelState] = useState(storage.getASRFallbackModel());
   const [modelMap, setModelMapState] = useState(storage.getASRModelMap());
   const [availableModels, setAvailableModels] = useState<ModelEntry[]>([]);
 
@@ -68,6 +69,11 @@ export const TTSSection: React.FC = () => {
   const setAsrFixedModel = (v: string) => {
     setAsrFixedModelState(v);
     storage.setASRFixedModel(v);
+  };
+
+  const setAsrFallbackModel = (v: string) => {
+    setAsrFallbackModelState(v);
+    storage.setASRFallbackModel(v);
   };
 
   const setModelMap = (map: Array<{ language: string; model: string }>) => {
@@ -234,6 +240,26 @@ export const TTSSection: React.FC = () => {
           >
             Add mapping
           </Button>
+          <FormControl fullWidth size="small" sx={{ mt: 2 }}>
+            <InputLabel>Fallback model (other languages)</InputLabel>
+            <Select
+              value={asrFallbackModel}
+              label="Fallback model (other languages)"
+              onChange={(e: SelectChangeEvent) => setAsrFallbackModel(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>Default (server)</em>
+              </MenuItem>
+              {availableModels.map((m) => (
+                <MenuItem key={m.id} value={m.name}>
+                  {m.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+            Used when the detected language doesn't match any mapping above.
+          </Typography>
         </Box>
       )}
 

--- a/src/components/settings/TTSSection.tsx
+++ b/src/components/settings/TTSSection.tsx
@@ -128,8 +128,8 @@ export const TTSSection: React.FC = () => {
         </Typography>
       </Box>
 
-      {/* Language → Model Mapping */}
-      <Box sx={{ mb: 3 }}>
+      {/* Language → Model Mapping — only shown for auto-route */}
+      {asrLanguage === 'auto-route' && <Box sx={{ mb: 3 }}>
         <Typography variant="subtitle2" sx={{ mb: 1 }}>
           Language → Model Mapping
         </Typography>
@@ -207,7 +207,7 @@ export const TTSSection: React.FC = () => {
         >
           Add mapping
         </Button>
-      </Box>
+      </Box>}
 
       <Divider sx={{ mb: 3 }} />
 

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -105,14 +105,27 @@ export const useMicStore = create<MicState>((set, get) => ({
           set({ status: 'processing' });
 
           try {
-            const language = storage.getASRLanguage() || undefined;
+            const langSetting = storage.getASRLanguage() || undefined;
             const { interactiveMode, interactionActive } = get();
             const mode = interactiveMode && !interactionActive ? 'fast' : undefined;
 
-            const response = await apiClient.transcribe(int16.buffer, { language, mode });
+            let language: string | undefined;
+            let model: string | undefined;
+
+            if (langSetting === 'auto-route') {
+              // Detect language first, then route to the mapped model
+              const detected = await apiClient.detectLanguage(int16.buffer);
+              language = detected.language || undefined;
+              model = language ? storage.getASRModelForLanguage(language) : undefined;
+            } else {
+              language = langSetting;
+              model = language ? storage.getASRModelForLanguage(language) : undefined;
+            }
+
+            const response = await apiClient.transcribe(int16.buffer, { language, mode, model });
 
             // Cache detected language on first auto-detect
-            if (!storage.getASRLanguage() && response.language) {
+            if (!langSetting && response.language) {
               storage.setASRLanguage(response.language);
             }
 

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -122,15 +122,11 @@ export const useMicStore = create<MicState>((set, get) => ({
               if (fixedModel) model = fixedModel;
             }
 
-            // Collect trigger words from all agents to bias recognition
-            const agents = useAgentStore.getState().agents;
-            const triggerWords = agents
-              .map((a) => a.persona?.trigger_word)
-              .filter((w): w is string => !!w?.trim())
-              .map((w) => w.trim());
-            const initial_prompt = triggerWords.length > 0
-              ? triggerWords.join(', ')
-              : undefined;
+            // Pass selected persona's trigger word to bias recognition
+            const { agents, selectedAgentId } = useAgentStore.getState();
+            const selectedAgent = agents.find((a) => a.id === selectedAgentId);
+            const triggerWord = selectedAgent?.persona?.trigger_word?.trim();
+            const initial_prompt = triggerWord || undefined;
 
             const response = await apiClient.transcribe(int16.buffer, { language, mode, model, initial_prompt });
 

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -124,8 +124,7 @@ export const useMicStore = create<MicState>((set, get) => ({
                 mappedLanguages.length > 0 ? { languages: mappedLanguages } : undefined,
               );
               language = detected.language || undefined;
-              const mappedModel = language ? storage.getASRModelForLanguage(language) : undefined;
-              model = mappedModel || storage.getASRFallbackModel() || undefined;
+              model = language ? storage.getASRModelForLanguage(language) : undefined;
             } else {
               const fixedModel = storage.getASRFixedModel();
               if (fixedModel) model = fixedModel;

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { MicVAD } from '@ricky0123/vad-web';
 import { apiClient } from '../api/client';
 import { storage } from '../utils/storage';
+import { useAgentStore } from './agentStore';
 
 export type ASRStatus = 'idle' | 'listening' | 'processing';
 
@@ -113,17 +114,25 @@ export const useMicStore = create<MicState>((set, get) => ({
             let model: string | undefined;
 
             if (asrMode === 'routing') {
-              // Detect language first, then route to the mapped model
               const detected = await apiClient.detectLanguage(int16.buffer);
               language = detected.language || undefined;
               model = language ? storage.getASRModelForLanguage(language) : undefined;
             } else {
-              // Fixed model mode
               const fixedModel = storage.getASRFixedModel();
               if (fixedModel) model = fixedModel;
             }
 
-            const response = await apiClient.transcribe(int16.buffer, { language, mode, model });
+            // Collect trigger words from all agents to bias recognition
+            const agents = useAgentStore.getState().agents;
+            const triggerWords = agents
+              .map((a) => a.persona?.trigger_word)
+              .filter((w): w is string => !!w?.trim())
+              .map((w) => w.trim());
+            const initial_prompt = triggerWords.length > 0
+              ? triggerWords.join(', ')
+              : undefined;
+
+            const response = await apiClient.transcribe(int16.buffer, { language, mode, model, initial_prompt });
 
             if (response.text.trim()) {
               _seq += 1;

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -124,7 +124,8 @@ export const useMicStore = create<MicState>((set, get) => ({
                 mappedLanguages.length > 0 ? { languages: mappedLanguages } : undefined,
               );
               language = detected.language || undefined;
-              model = language ? storage.getASRModelForLanguage(language) : undefined;
+              const mappedModel = language ? storage.getASRModelForLanguage(language) : undefined;
+              model = mappedModel || storage.getASRFallbackModel() || undefined;
             } else {
               const fixedModel = storage.getASRFixedModel();
               if (fixedModel) model = fixedModel;

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -114,7 +114,15 @@ export const useMicStore = create<MicState>((set, get) => ({
             let model: string | undefined;
 
             if (asrMode === 'routing') {
-              const detected = await apiClient.detectLanguage(int16.buffer);
+              // Only detect among languages that have a model mapping
+              const modelMap = storage.getASRModelMap();
+              const mappedLanguages = modelMap
+                .map((e) => e.language)
+                .filter((l) => !!l);
+              const detected = await apiClient.detectLanguage(
+                int16.buffer,
+                mappedLanguages.length > 0 ? { languages: mappedLanguages } : undefined,
+              );
               language = detected.language || undefined;
               model = language ? storage.getASRModelForLanguage(language) : undefined;
             } else {

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -105,29 +105,25 @@ export const useMicStore = create<MicState>((set, get) => ({
           set({ status: 'processing' });
 
           try {
-            const langSetting = storage.getASRLanguage() || undefined;
+            const asrMode = storage.getASRMode();
             const { interactiveMode, interactionActive } = get();
             const mode = interactiveMode && !interactionActive ? 'fast' : undefined;
 
             let language: string | undefined;
             let model: string | undefined;
 
-            if (langSetting === 'auto-route') {
+            if (asrMode === 'routing') {
               // Detect language first, then route to the mapped model
               const detected = await apiClient.detectLanguage(int16.buffer);
               language = detected.language || undefined;
               model = language ? storage.getASRModelForLanguage(language) : undefined;
             } else {
-              language = langSetting;
-              model = language ? storage.getASRModelForLanguage(language) : undefined;
+              // Fixed model mode
+              const fixedModel = storage.getASRFixedModel();
+              if (fixedModel) model = fixedModel;
             }
 
             const response = await apiClient.transcribe(int16.buffer, { language, mode, model });
-
-            // Cache detected language on first auto-detect
-            if (!langSetting && response.language) {
-              storage.setASRLanguage(response.language);
-            }
 
             if (response.text.trim()) {
               _seq += 1;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -18,6 +18,7 @@ const STORAGE_KEYS = {
   SELECTED_AGENT_ID: 'kurisu_selected_agent_id',
   AGENT_CONVERSATIONS: 'kurisu_agent_conversations',
   ASR_LANGUAGE: 'kurisu_asr_language',
+  ASR_MODEL_MAP: 'kurisu_asr_model_map',
 } as const;
 
 export const storage = {
@@ -405,5 +406,30 @@ export const storage = {
     } catch (error) {
       console.error('Failed to clear ASR language:', error);
     }
+  },
+
+  /** Language → ASR model mapping. Each entry: { language, model } */
+  getASRModelMap(): Array<{ language: string; model: string }> {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEYS.ASR_MODEL_MAP);
+      return raw ? JSON.parse(raw) : [];
+    } catch {
+      return [];
+    }
+  },
+
+  setASRModelMap(map: Array<{ language: string; model: string }>): void {
+    try {
+      localStorage.setItem(STORAGE_KEYS.ASR_MODEL_MAP, JSON.stringify(map));
+    } catch (error) {
+      console.error('Failed to save ASR model map:', error);
+    }
+  },
+
+  /** Look up the model for a given language code. Returns undefined if no mapping. */
+  getASRModelForLanguage(language: string): string | undefined {
+    const map = this.getASRModelMap();
+    const entry = map.find((e) => e.language === language);
+    return entry?.model;
   },
 };

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -20,7 +20,6 @@ const STORAGE_KEYS = {
   ASR_LANGUAGE: 'kurisu_asr_language',
   ASR_MODE: 'kurisu_asr_mode',
   ASR_FIXED_MODEL: 'kurisu_asr_fixed_model',
-  ASR_FALLBACK_MODEL: 'kurisu_asr_fallback_model',
   ASR_MODEL_MAP: 'kurisu_asr_model_map',
 } as const;
 
@@ -443,23 +442,6 @@ export const storage = {
       localStorage.setItem(STORAGE_KEYS.ASR_FIXED_MODEL, model);
     } catch (error) {
       console.error('Failed to save ASR fixed model:', error);
-    }
-  },
-
-  /** Fallback model for routing mode when detected language has no mapping. */
-  getASRFallbackModel(): string {
-    try {
-      return localStorage.getItem(STORAGE_KEYS.ASR_FALLBACK_MODEL) || '';
-    } catch {
-      return '';
-    }
-  },
-
-  setASRFallbackModel(model: string): void {
-    try {
-      localStorage.setItem(STORAGE_KEYS.ASR_FALLBACK_MODEL, model);
-    } catch (error) {
-      console.error('Failed to save ASR fallback model:', error);
     }
   },
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -20,6 +20,7 @@ const STORAGE_KEYS = {
   ASR_LANGUAGE: 'kurisu_asr_language',
   ASR_MODE: 'kurisu_asr_mode',
   ASR_FIXED_MODEL: 'kurisu_asr_fixed_model',
+  ASR_FALLBACK_MODEL: 'kurisu_asr_fallback_model',
   ASR_MODEL_MAP: 'kurisu_asr_model_map',
 } as const;
 
@@ -442,6 +443,23 @@ export const storage = {
       localStorage.setItem(STORAGE_KEYS.ASR_FIXED_MODEL, model);
     } catch (error) {
       console.error('Failed to save ASR fixed model:', error);
+    }
+  },
+
+  /** Fallback model for routing mode when detected language has no mapping. */
+  getASRFallbackModel(): string {
+    try {
+      return localStorage.getItem(STORAGE_KEYS.ASR_FALLBACK_MODEL) || '';
+    } catch {
+      return '';
+    }
+  },
+
+  setASRFallbackModel(model: string): void {
+    try {
+      localStorage.setItem(STORAGE_KEYS.ASR_FALLBACK_MODEL, model);
+    } catch (error) {
+      console.error('Failed to save ASR fallback model:', error);
     }
   },
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -18,6 +18,8 @@ const STORAGE_KEYS = {
   SELECTED_AGENT_ID: 'kurisu_selected_agent_id',
   AGENT_CONVERSATIONS: 'kurisu_agent_conversations',
   ASR_LANGUAGE: 'kurisu_asr_language',
+  ASR_MODE: 'kurisu_asr_mode',
+  ASR_FIXED_MODEL: 'kurisu_asr_fixed_model',
   ASR_MODEL_MAP: 'kurisu_asr_model_map',
 } as const;
 
@@ -405,6 +407,41 @@ export const storage = {
       localStorage.removeItem(STORAGE_KEYS.ASR_LANGUAGE);
     } catch (error) {
       console.error('Failed to clear ASR language:', error);
+    }
+  },
+
+  /** ASR mode: 'fixed' or 'routing'. Default 'fixed'. */
+  getASRMode(): 'fixed' | 'routing' {
+    try {
+      const v = localStorage.getItem(STORAGE_KEYS.ASR_MODE);
+      return v === 'routing' ? 'routing' : 'fixed';
+    } catch {
+      return 'fixed';
+    }
+  },
+
+  setASRMode(mode: 'fixed' | 'routing'): void {
+    try {
+      localStorage.setItem(STORAGE_KEYS.ASR_MODE, mode);
+    } catch (error) {
+      console.error('Failed to save ASR mode:', error);
+    }
+  },
+
+  /** Fixed model name for fixed mode. Empty = server default. */
+  getASRFixedModel(): string {
+    try {
+      return localStorage.getItem(STORAGE_KEYS.ASR_FIXED_MODEL) || '';
+    } catch {
+      return '';
+    }
+  },
+
+  setASRFixedModel(model: string): void {
+    try {
+      localStorage.setItem(STORAGE_KEYS.ASR_FIXED_MODEL, model);
+    } catch (error) {
+      console.error('Failed to save ASR fixed model:', error);
     }
   },
 


### PR DESCRIPTION
## Summary
- Replace free-text ASR language field with a dropdown (Auto-detect / Auto-route / specific languages)
- Add language→model mapping table in settings — assign specific ASR models per language (e.g. Vietnamese → PhoWhisper)
- **Auto (detect & route)** mode: detects language via fast transcription, then uses the mapped model for full transcription
- Model dropdown populated from universal-asr `/asr/models` endpoint

## Test plan
- [ ] Settings page shows language dropdown and mapping table
- [ ] Model dropdown populates with installed models from universal-asr
- [ ] Adding/removing mapping rows persists across page navigation
- [ ] Auto-route mode detects language and uses correct model
- [ ] Specific language mode passes model from mapping
- [ ] Auto-detect mode works as before (no model override)

Requires backend PR: Khoality-dev/KurisuAssistant#74

🤖 Generated with [Claude Code](https://claude.com/claude-code)