### PR TITLE
Always-listening ASR with PTT and trigger word activation

### DIFF
--- a/electron/appTools.ts
+++ b/electron/appTools.ts
@@ -42,6 +42,7 @@ const APP_TOOL_NAMES = new Set([
   'app_list_tools',
   'app_vision_start',
   'app_vision_stop',
+  'app_end_interaction',
   'app_launch_browser',
   'app_open_file',
   'app_open_folder',
@@ -347,6 +348,19 @@ function getAppToolSchemas(): ToolSchema[] {
       function: {
         name: 'app_vision_stop',
         description: 'Stop the camera/vision pipeline.',
+        parameters: {
+          type: 'object',
+          properties: {},
+          required: [],
+        },
+      },
+    },
+    // --- Voice interaction ---
+    {
+      type: 'function',
+      function: {
+        name: 'app_end_interaction',
+        description: 'End the current voice interaction session. Call this when the user indicates they are done — e.g. "that\'s all", "nothing else", "bye", "I\'ll call you later", "talk to you later", or similar farewell/dismissal phrases.',
         parameters: {
           type: 'object',
           properties: {},

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, protocol, shell, Tray, Menu, nativeImage } from 'electron';
+import { app, BrowserWindow, globalShortcut, ipcMain, protocol, shell, Tray, Menu, nativeImage } from 'electron';
 import path from 'path';
 import fs from 'fs';
 import https from 'https';
@@ -440,6 +440,22 @@ app.whenReady().then(() => {
 
   createTray();
   createWindow();
+
+  // Global PTT shortcut — double-press MediaPlayPause to toggle (avoids accidental triggers)
+  let lastMediaPress = 0;
+  globalShortcut.register('MediaPlayPause', () => {
+    const now = Date.now();
+    if (now - lastMediaPress < 500) {
+      // Double-press detected
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('ptt:toggle');
+      }
+      lastMediaPress = 0; // Reset to prevent triple-press counting as another double
+    } else {
+      lastMediaPress = now;
+    }
+  });
+
   registerMCPHandlers();
   registerHostToolIPC();
   registerAppToolIPC();
@@ -485,6 +501,7 @@ app.on('window-all-closed', () => {
 
 app.on('before-quit', () => {
   isQuitting = true;
+  globalShortcut.unregisterAll();
   cleanupMCP();
   stopMcpServer();
 });

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, globalShortcut, ipcMain, protocol, shell, Tray, Menu, nativeImage } from 'electron';
+import { app, BrowserWindow, ipcMain, protocol, shell, Tray, Menu, nativeImage } from 'electron';
 import path from 'path';
 import fs from 'fs';
 import https from 'https';
@@ -441,20 +441,53 @@ app.whenReady().then(() => {
   createTray();
   createWindow();
 
-  // Global PTT shortcut — double-press MediaPlayPause to toggle (avoids accidental triggers)
-  let lastMediaPress = 0;
-  globalShortcut.register('MediaPlayPause', () => {
-    const now = Date.now();
-    if (now - lastMediaPress < 500) {
-      // Double-press detected
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.send('ptt:toggle');
+  // Global PTT via uiohook-napi — captures any key globally including media keys
+  try {
+    const { uIOhook } = require('uiohook-napi');
+
+    let pttKeycode: number | null = null;
+    let lastPttPress = 0;
+
+    // IPC: renderer tells main which keycode to use for PTT
+    ipcMain.on('ptt:set-keycode', (_event: any, keycode: number | null) => {
+      pttKeycode = keycode;
+      console.log('PTT keycode set to:', keycode);
+    });
+
+    // IPC: renderer requests key capture mode (next key press is sent back)
+    let capturingKey = false;
+    ipcMain.on('ptt:capture-start', () => { capturingKey = true; });
+    ipcMain.on('ptt:capture-stop', () => { capturingKey = false; });
+
+    uIOhook.on('keydown', (e: any) => {
+      // Key capture mode: send the keycode back to renderer
+      if (capturingKey) {
+        capturingKey = false;
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send('ptt:key-captured', e.keycode);
+        }
+        return;
       }
-      lastMediaPress = 0; // Reset to prevent triple-press counting as another double
-    } else {
-      lastMediaPress = now;
-    }
-  });
+
+      // PTT double-press toggle
+      if (pttKeycode !== null && e.keycode === pttKeycode) {
+        const now = Date.now();
+        if (now - lastPttPress < 500) {
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            mainWindow.webContents.send('ptt:toggle');
+          }
+          lastPttPress = 0;
+        } else {
+          lastPttPress = now;
+        }
+      }
+    });
+
+    uIOhook.start();
+    console.log('uiohook started for global PTT');
+  } catch (err) {
+    console.error('Failed to start uiohook:', err);
+  }
 
   registerMCPHandlers();
   registerHostToolIPC();
@@ -501,7 +534,7 @@ app.on('window-all-closed', () => {
 
 app.on('before-quit', () => {
   isQuitting = true;
-  globalShortcut.unregisterAll();
+  try { require('uiohook-napi').uIOhook.stop(); } catch {}
   cleanupMCP();
   stopMcpServer();
 });

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -24,6 +24,14 @@ contextBridge.exposeInMainWorld('electron', {
     installUpdate: () => ipcRenderer.send('updater:install'),
   },
 
+  ptt: {
+    onToggle: (cb: () => void) => {
+      const handler = () => cb();
+      ipcRenderer.on('ptt:toggle', handler);
+      return () => { ipcRenderer.removeListener('ptt:toggle', handler); };
+    },
+  },
+
   extensions: {
     checkHealth: (url: string) => ipcRenderer.invoke('extensions:check-health', url),
     checkInstalled: (appName: string) => ipcRenderer.invoke('extensions:check-installed', appName),

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -30,6 +30,14 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.on('ptt:toggle', handler);
       return () => { ipcRenderer.removeListener('ptt:toggle', handler); };
     },
+    setKeycode: (keycode: number | null) => ipcRenderer.send('ptt:set-keycode', keycode),
+    startCapture: () => ipcRenderer.send('ptt:capture-start'),
+    stopCapture: () => ipcRenderer.send('ptt:capture-stop'),
+    onKeyCaptured: (cb: (keycode: number) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, keycode: number) => cb(keycode);
+      ipcRenderer.on('ptt:key-captured', handler);
+      return () => { ipcRenderer.removeListener('ptt:key-captured', handler); };
+    },
   },
 
   extensions: {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -377,11 +377,12 @@ class APIClient {
    */
   async transcribe(
     audio: ArrayBuffer,
-    options?: { language?: string; model?: string; initial_prompt?: string },
+    options?: { language?: string; model?: string; initial_prompt?: string; fast?: boolean },
   ): Promise<{ text: string; language: string }> {
     const params: Record<string, string> = {};
     if (options?.language) params.language = options.language;
     if (options?.model) params.model = options.model;
+    if (options?.fast) params.fast = 'true';
     if (options?.initial_prompt) params.initial_prompt = options.initial_prompt;
 
     const response = await this.client.post<{ text: string; language: string }>('/asr', audio, {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -377,11 +377,10 @@ class APIClient {
    */
   async transcribe(
     audio: ArrayBuffer,
-    options?: { language?: string; mode?: string; model?: string; initial_prompt?: string },
+    options?: { language?: string; model?: string; initial_prompt?: string },
   ): Promise<{ text: string; language: string }> {
     const params: Record<string, string> = {};
     if (options?.language) params.language = options.language;
-    if (options?.mode) params.mode = options.mode;
     if (options?.model) params.model = options.model;
     if (options?.initial_prompt) params.initial_prompt = options.initial_prompt;
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -377,12 +377,11 @@ class APIClient {
    */
   async transcribe(
     audio: ArrayBuffer,
-    options?: { language?: string; model?: string; initial_prompt?: string; fast?: boolean },
+    options?: { language?: string; model?: string; initial_prompt?: string },
   ): Promise<{ text: string; language: string }> {
     const params: Record<string, string> = {};
     if (options?.language) params.language = options.language;
     if (options?.model) params.model = options.model;
-    if (options?.fast) params.fast = 'true';
     if (options?.initial_prompt) params.initial_prompt = options.initial_prompt;
 
     const response = await this.client.post<{ text: string; language: string }>('/asr', audio, {

--- a/src/components/chat/ChatComposer.tsx
+++ b/src/components/chat/ChatComposer.tsx
@@ -40,7 +40,7 @@ const MicIndicator: React.FC = () => {
     const update = () => {
       if (iconRef.current) {
         const active = getMicAmplitude() > 0.15;
-        iconRef.current.style.color = active ? '#f44336' : '';
+        iconRef.current.style.color = active ? '#4caf50' : '';
       }
       raf = requestAnimationFrame(update);
     };

--- a/src/components/chat/ChatComposer.tsx
+++ b/src/components/chat/ChatComposer.tsx
@@ -25,7 +25,49 @@ import {
   Stop as StopIcon,
   Videocam as VideocamIcon,
   VideocamOff as VideocamOffIcon,
+  Mic as MicIcon,
 } from '@mui/icons-material';
+import { useMicStore } from '../../store/micStore';
+
+/** Compact mic status indicator with speech probability bar */
+const MicIndicator: React.FC = () => {
+  const status = useMicStore((s) => s.status);
+  const prob = useMicStore((s) => s.speechProbability);
+
+  if (status === 'idle') return null;
+
+  const isProcessing = status === 'processing';
+  const barHeight = Math.max(4, prob * 20);
+
+  return (
+    <Tooltip title={isProcessing ? 'Processing speech...' : 'Listening'}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, px: 0.5 }}>
+        <MicIcon
+          sx={{
+            fontSize: 18,
+            color: isProcessing ? 'warning.main' : prob > 0.5 ? 'error.main' : 'text.secondary',
+            transition: 'color 0.15s',
+          }}
+        />
+        {/* Amplitude bars */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '2px', height: 20 }}>
+          {[0.2, 0.4, 0.6, 0.8].map((threshold) => (
+            <Box
+              key={threshold}
+              sx={{
+                width: 3,
+                height: prob > threshold ? barHeight : 4,
+                borderRadius: 1,
+                bgcolor: prob > threshold ? 'error.main' : 'action.disabled',
+                transition: 'height 0.1s, background-color 0.1s',
+              }}
+            />
+          ))}
+        </Box>
+      </Box>
+    </Tooltip>
+  );
+};
 
 export interface ChatComposerProps {
   scopeKey: string;
@@ -264,6 +306,8 @@ export const ChatComposer: React.FC<ChatComposerProps> = React.memo(({
             <MenuItem disabled>No webcams found</MenuItem>
           )}
         </Menu>
+
+        <MicIndicator />
 
         <TextField
           ref={textFieldRef}

--- a/src/components/chat/ChatComposer.tsx
+++ b/src/components/chat/ChatComposer.tsx
@@ -52,10 +52,12 @@ const MicIndicator: React.FC = () => {
 
   return (
     <Tooltip title={status === 'processing' ? 'Processing...' : 'Listening'}>
-      <MicIcon
-        ref={iconRef}
-        sx={{ fontSize: 18, color: 'text.secondary' }}
-      />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: 40, height: 40 }}>
+        <MicIcon
+          ref={iconRef}
+          sx={{ fontSize: 20, color: 'text.secondary' }}
+        />
+      </Box>
     </Tooltip>
   );
 };

--- a/src/components/chat/ChatComposer.tsx
+++ b/src/components/chat/ChatComposer.tsx
@@ -23,33 +23,21 @@ import {
   AttachFile as AttachFileIcon,
   Close as CloseIcon,
   Stop as StopIcon,
-  Mic as MicIcon,
-  MicOff as MicOffIcon,
   Videocam as VideocamIcon,
   VideocamOff as VideocamOffIcon,
 } from '@mui/icons-material';
-import CircularProgress from '@mui/material/CircularProgress';
-import type { useMicStore } from '../../store/micStore';
 
 export interface ChatComposerProps {
   scopeKey: string;
   externalDraft: string;
   externalDraftVersion: number;
   isStreaming: boolean;
-  asrStatus: ReturnType<typeof useMicStore.getState>['status'];
-  asrDevices: ReturnType<typeof useMicStore.getState>['devices'];
-  asrDeviceId: ReturnType<typeof useMicStore.getState>['selectedDeviceId'];
-  micMenuAnchor: HTMLElement | null;
   cameraActive: boolean;
   cameraWebcams: string[];
   cameraSelectedWebcam: string | null;
   cameraMenuAnchor: HTMLElement | null;
   onSend: (text: string, imageFiles: File[]) => Promise<void>;
   onCancel: () => void;
-  onMicToggle: () => void;
-  onMicContext: (e: React.MouseEvent<HTMLElement>) => void;
-  onCloseMicMenu: () => void;
-  onSelectAsrDevice: (deviceId: string) => void;
   onCameraToggle: () => Promise<void>;
   onCameraContext: (e: React.MouseEvent<HTMLElement>) => void;
   onCloseCameraMenu: () => void;
@@ -64,20 +52,12 @@ export const ChatComposer: React.FC<ChatComposerProps> = React.memo(({
   externalDraft,
   externalDraftVersion,
   isStreaming,
-  asrStatus,
-  asrDevices,
-  asrDeviceId,
-  micMenuAnchor,
   cameraActive,
   cameraWebcams,
   cameraSelectedWebcam,
   cameraMenuAnchor,
   onSend,
   onCancel,
-  onMicToggle,
-  onMicContext,
-  onCloseMicMenu,
-  onSelectAsrDevice,
   onCameraToggle,
   onCameraContext,
   onCloseCameraMenu,
@@ -243,47 +223,6 @@ export const ChatComposer: React.FC<ChatComposerProps> = React.memo(({
         >
           <AttachFileIcon />
         </IconButton>
-
-        <Tooltip title={asrStatus === 'idle' ? 'Start dictation (right-click: select mic)' : 'Stop dictation'}>
-          <IconButton
-            onClick={onMicToggle}
-            onContextMenu={onMicContext}
-            sx={{
-              color: asrStatus === 'listening' ? 'error.main' : 'inherit',
-            }}
-          >
-            {asrStatus === 'processing' ? (
-              <CircularProgress size={24} />
-            ) : asrStatus === 'listening' ? (
-              <MicIcon />
-            ) : (
-              <MicOffIcon />
-            )}
-          </IconButton>
-        </Tooltip>
-        <Menu
-          anchorEl={micMenuAnchor}
-          open={Boolean(micMenuAnchor)}
-          onClose={onCloseMicMenu}
-        >
-          {asrDevices.map((device) => (
-            <MenuItem
-              key={device.deviceId}
-              onClick={() => onSelectAsrDevice(device.deviceId)}
-              selected={device.deviceId === asrDeviceId}
-            >
-              {device.deviceId === asrDeviceId && (
-                <ListItemIcon><CheckIcon fontSize="small" /></ListItemIcon>
-              )}
-              <ListItemText inset={device.deviceId !== asrDeviceId}>
-                {device.label}
-              </ListItemText>
-            </MenuItem>
-          ))}
-          {asrDevices.length === 0 && (
-            <MenuItem disabled>No microphones found</MenuItem>
-          )}
-        </Menu>
 
         <Tooltip title={cameraActive ? 'Stop camera (right-click: select webcam)' : 'Start camera (right-click: select webcam)'}>
           <IconButton

--- a/src/components/chat/ChatComposer.tsx
+++ b/src/components/chat/ChatComposer.tsx
@@ -37,10 +37,14 @@ const MicIndicator: React.FC = () => {
   useEffect(() => {
     if (status === 'idle') return;
     let raf = 0;
+    let smoothed = 0;
     const update = () => {
       if (iconRef.current) {
-        const active = getMicAmplitude() > 0.15;
-        iconRef.current.style.color = active ? '#4caf50' : '';
+        const raw = getMicAmplitude();
+        // EMA smoothing: fast attack, slow decay
+        smoothed += (raw - smoothed) * (raw > smoothed ? 0.3 : 0.08);
+        const opacity = Math.min(1, smoothed / 0.15);
+        iconRef.current.style.color = `rgba(76, 175, 80, ${opacity})`;
       }
       raf = requestAnimationFrame(update);
     };

--- a/src/components/chat/ChatComposer.tsx
+++ b/src/components/chat/ChatComposer.tsx
@@ -27,44 +27,35 @@ import {
   VideocamOff as VideocamOffIcon,
   Mic as MicIcon,
 } from '@mui/icons-material';
-import { useMicStore } from '../../store/micStore';
+import { useMicStore, getMicAmplitude } from '../../store/micStore';
 
-/** Compact mic status indicator with speech probability bar */
+/** Mic icon that lights up when sound is detected */
 const MicIndicator: React.FC = () => {
   const status = useMicStore((s) => s.status);
-  const prob = useMicStore((s) => s.speechProbability);
+  const iconRef = useRef<SVGSVGElement | null>(null);
+
+  useEffect(() => {
+    if (status === 'idle') return;
+    let raf = 0;
+    const update = () => {
+      if (iconRef.current) {
+        const active = getMicAmplitude() > 0.15;
+        iconRef.current.style.color = active ? '#f44336' : '';
+      }
+      raf = requestAnimationFrame(update);
+    };
+    raf = requestAnimationFrame(update);
+    return () => cancelAnimationFrame(raf);
+  }, [status]);
 
   if (status === 'idle') return null;
 
-  const isProcessing = status === 'processing';
-  const barHeight = Math.max(4, prob * 20);
-
   return (
-    <Tooltip title={isProcessing ? 'Processing speech...' : 'Listening'}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, px: 0.5 }}>
-        <MicIcon
-          sx={{
-            fontSize: 18,
-            color: isProcessing ? 'warning.main' : prob > 0.5 ? 'error.main' : 'text.secondary',
-            transition: 'color 0.15s',
-          }}
-        />
-        {/* Amplitude bars */}
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: '2px', height: 20 }}>
-          {[0.2, 0.4, 0.6, 0.8].map((threshold) => (
-            <Box
-              key={threshold}
-              sx={{
-                width: 3,
-                height: prob > threshold ? barHeight : 4,
-                borderRadius: 1,
-                bgcolor: prob > threshold ? 'error.main' : 'action.disabled',
-                transition: 'height 0.1s, background-color 0.1s',
-              }}
-            />
-          ))}
-        </Box>
-      </Box>
+    <Tooltip title={status === 'processing' ? 'Processing...' : 'Listening'}>
+      <MicIcon
+        ref={iconRef}
+        sx={{ fontSize: 18, color: 'text.secondary' }}
+      />
     </Tooltip>
   );
 };

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -27,6 +27,7 @@ import { useTTS } from '../../hooks/useTTS';
 import { useVisionStore } from '../../store/visionStore';
 import { useCharacterPanel } from '../../hooks/useCharacterPanel';
 import { useInteractiveASR } from '../../hooks/useInteractiveASR';
+import { useMicStore } from '../../store/micStore';
 import { useStreamingChat } from '../../hooks/useStreamingChat';
 import { InteractiveCallBar } from '../InteractiveCallBar';
 import { MessageBubble } from './MessageBubble';

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -199,31 +199,19 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
       }
     };
 
-    // Media Session API for headset buttons
-    let mediaSessionActive = false;
-    const handlePlay = () => {
-      if (!mediaSessionActive) {
-        mediaSessionActive = true;
-        activatePTT();
-      }
-    };
-    const handlePause = () => {
-      if (mediaSessionActive) {
-        mediaSessionActive = false;
-        deactivatePTT();
-      }
-    };
-    if (navigator.mediaSession) {
-      // Create a silent audio context to activate media session
-      try {
-        const audio = new Audio();
-        audio.src = 'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=';
-        audio.loop = true;
-        audio.volume = 0;
-        audio.play().catch(() => {});
-      } catch {}
-      navigator.mediaSession.setActionHandler('play', handlePlay);
-      navigator.mediaSession.setActionHandler('pause', handlePause);
+    // Headset button via Electron global shortcut (double-press MediaPlayPause)
+    // Uses activateInteraction (not PTT) so the 30s idle timer applies
+    const electron = (window as any).electron;
+    let cleanupPTT: (() => void) | undefined;
+    if (electron?.ptt?.onToggle) {
+      cleanupPTT = electron.ptt.onToggle(() => {
+        const mic = useMicStore.getState();
+        if (mic.interactionActive) {
+          mic.deactivateInteraction();
+        } else {
+          mic.activateInteraction();
+        }
+      });
     }
 
     window.addEventListener('keydown', handleKeyDown);
@@ -231,10 +219,7 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('keyup', handleKeyUp);
-      if (navigator.mediaSession) {
-        navigator.mediaSession.setActionHandler('play', null);
-        navigator.mediaSession.setActionHandler('pause', null);
-      }
+      cleanupPTT?.();
     };
   }, []);
 

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -28,6 +28,7 @@ import { useVisionStore } from '../../store/visionStore';
 import { useCharacterPanel } from '../../hooks/useCharacterPanel';
 import { useInteractiveASR } from '../../hooks/useInteractiveASR';
 import { useMicStore } from '../../store/micStore';
+import { storage } from '../../utils/storage';
 import { useAgentStore } from '../../store/agentStore';
 import { useStreamingChat } from '../../hooks/useStreamingChat';
 import { InteractiveCallBar } from '../InteractiveCallBar';
@@ -172,32 +173,32 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     pushExternalDraft: streaming.pushExternalDraft,
   });
 
-  // Always-listen: auto-start mic on mount
+  // Always-listen: auto-start mic on mount + send PTT keycode to main process
   useEffect(() => {
     useMicStore.getState().initAlwaysListen();
+    const electron = (window as any).electron;
+    const keycode = storage.getPTTKeycode();
+    if (keycode !== null) electron?.ptt?.setKeycode(keycode);
   }, []);
 
   // Push-to-talk: Ctrl+Space or headset MediaPlayPause
   useEffect(() => {
     const { activatePTT, deactivatePTT } = useMicStore.getState();
 
+    // Ctrl+Space: hold-to-talk
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.repeat) return;
-      const isCtrlSpace = e.ctrlKey && e.code === 'Space';
-      const isMediaPlay = e.key === 'MediaPlayPause';
-      if (isCtrlSpace || isMediaPlay) {
+      if (e.ctrlKey && e.code === 'Space') {
         e.preventDefault();
         activatePTT();
       }
     };
-
     const handleKeyUp = (e: KeyboardEvent) => {
-      const isCtrlSpace = e.code === 'Space';
-      const isMediaPlay = e.key === 'MediaPlayPause';
-      if (isCtrlSpace || isMediaPlay) {
+      if (e.code === 'Space') {
         deactivatePTT();
       }
     };
+
 
     // Headset button via Electron global shortcut (double-press MediaPlayPause)
     // Uses activateInteraction (not PTT) so the 30s idle timer applies

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -493,20 +493,12 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
           externalDraft={streaming.externalDraft}
           externalDraftVersion={streaming.externalDraftVersion}
           isStreaming={streaming.isStreaming}
-          asrStatus={asr.asrStatus}
-          asrDevices={asr.asrDevices}
-          asrDeviceId={asr.asrDeviceId}
-          micMenuAnchor={asr.micMenuAnchor}
           cameraActive={cameraActive}
           cameraWebcams={cameraWebcams}
           cameraSelectedWebcam={cameraSelectedWebcam}
           cameraMenuAnchor={cameraMenuAnchor}
           onSend={streaming.handleSend}
           onCancel={streaming.handleCancel}
-          onMicToggle={asr.handleMicToggle}
-          onMicContext={asr.handleMicContext}
-          onCloseMicMenu={asr.closeMicMenu}
-          onSelectAsrDevice={asr.selectAsrDevice}
           onCameraToggle={handleCameraToggle}
           onCameraContext={handleCameraContext}
           onCloseCameraMenu={() => setCameraMenuAnchor(null)}

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -166,6 +166,7 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     isStreaming: streaming.isStreaming,
     isQueueActive,
     handleSendText: streaming.handleSendText,
+    pushExternalDraft: streaming.pushExternalDraft,
   });
 
   // Always-listen: auto-start mic on mount

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -199,11 +199,42 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
       }
     };
 
+    // Media Session API for headset buttons
+    let mediaSessionActive = false;
+    const handlePlay = () => {
+      if (!mediaSessionActive) {
+        mediaSessionActive = true;
+        activatePTT();
+      }
+    };
+    const handlePause = () => {
+      if (mediaSessionActive) {
+        mediaSessionActive = false;
+        deactivatePTT();
+      }
+    };
+    if (navigator.mediaSession) {
+      // Create a silent audio context to activate media session
+      try {
+        const audio = new Audio();
+        audio.src = 'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=';
+        audio.loop = true;
+        audio.volume = 0;
+        audio.play().catch(() => {});
+      } catch {}
+      navigator.mediaSession.setActionHandler('play', handlePlay);
+      navigator.mediaSession.setActionHandler('pause', handlePause);
+    }
+
     window.addEventListener('keydown', handleKeyDown);
     window.addEventListener('keyup', handleKeyUp);
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('keyup', handleKeyUp);
+      if (navigator.mediaSession) {
+        navigator.mediaSession.setActionHandler('play', null);
+        navigator.mediaSession.setActionHandler('pause', null);
+      }
     };
   }, []);
 

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -28,6 +28,7 @@ import { useVisionStore } from '../../store/visionStore';
 import { useCharacterPanel } from '../../hooks/useCharacterPanel';
 import { useInteractiveASR } from '../../hooks/useInteractiveASR';
 import { useMicStore } from '../../store/micStore';
+import { useAgentStore } from '../../store/agentStore';
 import { useStreamingChat } from '../../hooks/useStreamingChat';
 import { InteractiveCallBar } from '../InteractiveCallBar';
 import { MessageBubble } from './MessageBubble';
@@ -41,7 +42,9 @@ interface ChatWidgetProps {
   agentId?: number | null;
 }
 
-export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = false, agentId = null }) => {
+export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = false, agentId: agentIdProp = null }) => {
+  const storeAgentId = useAgentStore((s) => s.selectedAgentId);
+  const agentId = agentIdProp ?? storeAgentId;
   const {
     messages,
     frames,

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -165,9 +165,42 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
     isStreaming: streaming.isStreaming,
     isQueueActive,
     handleSendText: streaming.handleSendText,
-    pushExternalDraft: streaming.pushExternalDraft,
-    clearExternalDraft: streaming.clearExternalDraft,
   });
+
+  // Always-listen: auto-start mic on mount
+  useEffect(() => {
+    useMicStore.getState().initAlwaysListen();
+  }, []);
+
+  // Push-to-talk: Ctrl+Space or headset MediaPlayPause
+  useEffect(() => {
+    const { activatePTT, deactivatePTT } = useMicStore.getState();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.repeat) return;
+      const isCtrlSpace = e.ctrlKey && e.code === 'Space';
+      const isMediaPlay = e.key === 'MediaPlayPause';
+      if (isCtrlSpace || isMediaPlay) {
+        e.preventDefault();
+        activatePTT();
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      const isCtrlSpace = e.code === 'Space';
+      const isMediaPlay = e.key === 'MediaPlayPause';
+      if (isCtrlSpace || isMediaPlay) {
+        deactivatePTT();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, []);
 
   // Vision (camera toggle)
   const {
@@ -478,14 +511,14 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
             : (value) => streaming.respondToApproval(value === 'approve')
           }
         />
-      ) : asr.interactiveMode ? (
+      ) : asr.interactionActive ? (
         <InteractiveCallBar
           asrStatus={asr.asrStatus}
           interactionActive={asr.interactionActive}
           lastTranscript={asr.lastTranscript}
           isStreaming={streaming.isStreaming}
           isTTSPlaying={isQueueActive}
-          onHangUp={asr.disableInteractiveMode}
+          onHangUp={() => useMicStore.getState().deactivateInteraction()}
         />
       ) : (
         <ChatComposer

--- a/src/components/layout/ChatPanel.tsx
+++ b/src/components/layout/ChatPanel.tsx
@@ -4,17 +4,13 @@ import {
   Refresh as RefreshIcon,
   Delete as DeleteIcon,
   Face as FaceIcon,
-  Phone as PhoneIcon,
-  PhoneDisabled as PhoneDisabledIcon,
 } from '@mui/icons-material';
 import { useConversationStore } from '../../store/conversationStore';
-import { useMicStore } from '../../store/micStore';
 import { ChatWidget } from '../chat/ChatWidget';
 import { MediaPlayerBar } from '../MediaPlayerBar';
 
 export const ChatPanel: React.FC = () => {
   const { currentConversation, deleteConversation } = useConversationStore();
-  const { interactiveMode, enableInteractiveMode, disableInteractiveMode } = useMicStore();
   const [characterVisible, setCharacterVisible] = useState(false);
 
   const handleRefresh = () => {
@@ -57,15 +53,6 @@ export const ChatPanel: React.FC = () => {
           Chat
         </Typography>
 
-        <Tooltip title={interactiveMode ? 'End Call' : 'Start Call'}>
-          <IconButton
-            size="small"
-            onClick={() => interactiveMode ? disableInteractiveMode() : enableInteractiveMode()}
-            sx={{ color: interactiveMode ? 'error.main' : 'text.secondary' }}
-          >
-            {interactiveMode ? <PhoneDisabledIcon fontSize="small" /> : <PhoneIcon fontSize="small" />}
-          </IconButton>
-        </Tooltip>
         <Tooltip title={characterVisible ? 'Hide Character' : 'Show Character'}>
           <IconButton
             size="small"

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box, List, ListItemButton, ListItemIcon, ListItemText, Typography } from '@mui/material';
 import {
   Person as AccountIcon,
+  Mic as VoiceIcon,
   RecordVoiceOver as TTSIcon,
   Palette as AppearanceIcon,
   EmojiPeople as PersonasIcon,
@@ -16,6 +17,7 @@ import { useLayoutStore } from '../../store/layoutStore';
 
 // Lazy imports for settings sections
 const AccountSection = React.lazy(() => import('./AccountSection').then(m => ({ default: m.AccountSection })));
+const VoiceSection = React.lazy(() => import('./VoiceSection').then(m => ({ default: m.VoiceSection })));
 const TTSSection = React.lazy(() => import('./TTSSection').then(m => ({ default: m.TTSSection })));
 const AppearanceSection = React.lazy(() => import('./AppearanceSection').then(m => ({ default: m.AppearanceSection })));
 const PersonasSection = React.lazy(() => import('./PersonasSection').then(m => ({ default: m.PersonasSection })));
@@ -34,6 +36,7 @@ interface SettingsItem {
 
 const SETTINGS_ITEMS: SettingsItem[] = [
   { id: 'account', label: 'Account', icon: <AccountIcon /> },
+  { id: 'voice', label: 'Voice', icon: <VoiceIcon /> },
   { id: 'tts', label: 'TTS & ASR', icon: <TTSIcon /> },
   { id: 'appearance', label: 'Appearance', icon: <AppearanceIcon /> },
   { id: 'personas', label: 'Personas', icon: <PersonasIcon /> },
@@ -48,6 +51,7 @@ const SETTINGS_ITEMS: SettingsItem[] = [
 function renderSection(sectionId: string) {
   switch (sectionId) {
     case 'account': return <AccountSection />;
+    case 'voice': return <VoiceSection />;
     case 'tts': return <TTSSection />;
     case 'appearance': return <AppearanceSection />;
     case 'personas': return <PersonasSection />;

--- a/src/components/settings/TTSSection.tsx
+++ b/src/components/settings/TTSSection.tsx
@@ -23,6 +23,7 @@ import AddIcon from '@mui/icons-material/Add';
 import { useTTS } from '../../hooks/useTTS';
 import { storage } from '../../utils/storage';
 import { apiClient } from '../../api/client';
+import { useMicStore } from '../../store/micStore';
 
 interface ModelEntry {
   id: string;
@@ -48,11 +49,23 @@ export const TTSSection: React.FC = () => {
   const { backends, loadBackends } = useTTS();
 
   // ASR settings
+  const [alwaysListen, setAlwaysListenState] = useState(storage.getASRAlwaysListen());
   const [asrMode, setAsrModeState] = useState(storage.getASRMode());
   const [asrLanguage, setAsrLanguageState] = useState(storage.getASRLanguage() || '');
   const [asrFixedModel, setAsrFixedModelState] = useState(storage.getASRFixedModel());
   const [modelMap, setModelMapState] = useState(storage.getASRModelMap());
   const [availableModels, setAvailableModels] = useState<ModelEntry[]>([]);
+
+  const setAlwaysListen = (v: boolean) => {
+    setAlwaysListenState(v);
+    storage.setASRAlwaysListen(v);
+    const mic = useMicStore.getState();
+    if (v && mic.status === 'idle') {
+      mic.startListening();
+    } else if (!v && mic.status !== 'idle') {
+      mic.stopListening();
+    }
+  };
 
   const setAsrMode = (v: 'fixed' | 'routing') => {
     setAsrModeState(v);
@@ -111,6 +124,22 @@ export const TTSSection: React.FC = () => {
   return (
     <Box sx={{ maxWidth: 700 }}>
       <Typography variant="h3" sx={{ mb: 3 }}>TTS & ASR</Typography>
+
+      {/* Always Listen */}
+      <Box sx={{ mb: 3 }}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={alwaysListen}
+              onChange={(e) => setAlwaysListen(e.target.checked)}
+            />
+          }
+          label="Always listen"
+        />
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+          Keep microphone active to detect trigger words or push-to-talk (Ctrl+Space). Disable to save resources.
+        </Typography>
+      </Box>
 
       {/* ASR Mode */}
       <Box sx={{ mb: 3 }}>

--- a/src/components/settings/TTSSection.tsx
+++ b/src/components/settings/TTSSection.tsx
@@ -23,7 +23,6 @@ import AddIcon from '@mui/icons-material/Add';
 import { useTTS } from '../../hooks/useTTS';
 import { storage } from '../../utils/storage';
 import { apiClient } from '../../api/client';
-import { useMicStore } from '../../store/micStore';
 
 interface ModelEntry {
   id: string;
@@ -49,25 +48,11 @@ export const TTSSection: React.FC = () => {
   const { backends, loadBackends } = useTTS();
 
   // ASR settings
-  const [micDevices, setMicDevices] = useState<Array<{ deviceId: string; label: string }>>([]);
-  const [selectedMicId, setSelectedMicIdState] = useState(storage.getASRDeviceId() || '');
-  const [alwaysListen, setAlwaysListenState] = useState(storage.getASRAlwaysListen());
   const [asrMode, setAsrModeState] = useState(storage.getASRMode());
   const [asrLanguage, setAsrLanguageState] = useState(storage.getASRLanguage() || '');
   const [asrFixedModel, setAsrFixedModelState] = useState(storage.getASRFixedModel());
   const [modelMap, setModelMapState] = useState(storage.getASRModelMap());
   const [availableModels, setAvailableModels] = useState<ModelEntry[]>([]);
-
-  const setAlwaysListen = (v: boolean) => {
-    setAlwaysListenState(v);
-    storage.setASRAlwaysListen(v);
-    const mic = useMicStore.getState();
-    if (v && mic.status === 'idle') {
-      mic.startListening();
-    } else if (!v && mic.status !== 'idle') {
-      mic.stopListening();
-    }
-  };
 
   const setAsrMode = (v: 'fixed' | 'routing') => {
     setAsrModeState(v);
@@ -102,32 +87,10 @@ export const TTSSection: React.FC = () => {
   const setTtsEmotionAlpha = (v: number) => { setTtsEmotionAlphaState(v); storage.setTTSEmotionAlpha(v); };
   const setTtsUseEmotionText = (v: boolean) => { setTtsUseEmotionTextState(v); storage.setTTSUseEmotionText(v); };
 
-  const setSelectedMicId = (deviceId: string) => {
-    setSelectedMicIdState(deviceId);
-    if (deviceId) {
-      storage.setASRDeviceId(deviceId);
-      useMicStore.getState().selectDevice(deviceId);
-    }
-  };
-
   useEffect(() => {
     loadBackends();
     apiClient.getASRModels()
       .then((models) => setAvailableModels(models.map((m) => ({ id: m.id, name: m.name }))))
-      .catch(() => {});
-    // Load mic devices
-    navigator.mediaDevices.getUserMedia({ audio: true })
-      .then((stream) => {
-        stream.getTracks().forEach((t) => t.stop());
-        return navigator.mediaDevices.enumerateDevices();
-      })
-      .then((devices) => {
-        setMicDevices(
-          devices
-            .filter((d) => d.kind === 'audioinput')
-            .map((d) => ({ deviceId: d.deviceId, label: d.label || `Microphone ${d.deviceId.slice(0, 8)}` }))
-        );
-      })
       .catch(() => {});
   }, [loadBackends]);
 
@@ -148,43 +111,6 @@ export const TTSSection: React.FC = () => {
   return (
     <Box sx={{ maxWidth: 700 }}>
       <Typography variant="h3" sx={{ mb: 3 }}>TTS & ASR</Typography>
-
-      {/* Always Listen */}
-      <Box sx={{ mb: 3 }}>
-        <FormControlLabel
-          control={
-            <Switch
-              checked={alwaysListen}
-              onChange={(e) => setAlwaysListen(e.target.checked)}
-            />
-          }
-          label="Always listen"
-        />
-        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-          Keep microphone active to detect trigger words or push-to-talk (Ctrl+Space). Disable to save resources.
-        </Typography>
-      </Box>
-
-      {/* Microphone Selection */}
-      <Box sx={{ mb: 3 }}>
-        <FormControl fullWidth size="small">
-          <InputLabel>Microphone</InputLabel>
-          <Select
-            value={selectedMicId}
-            label="Microphone"
-            onChange={(e: SelectChangeEvent) => setSelectedMicId(e.target.value)}
-          >
-            <MenuItem value="">
-              <em>Default</em>
-            </MenuItem>
-            {micDevices.map((d) => (
-              <MenuItem key={d.deviceId} value={d.deviceId}>
-                {d.label}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-      </Box>
 
       {/* ASR Mode */}
       <Box sx={{ mb: 3 }}>

--- a/src/components/settings/TTSSection.tsx
+++ b/src/components/settings/TTSSection.tsx
@@ -49,6 +49,8 @@ export const TTSSection: React.FC = () => {
   const { backends, loadBackends } = useTTS();
 
   // ASR settings
+  const [micDevices, setMicDevices] = useState<Array<{ deviceId: string; label: string }>>([]);
+  const [selectedMicId, setSelectedMicIdState] = useState(storage.getASRDeviceId() || '');
   const [alwaysListen, setAlwaysListenState] = useState(storage.getASRAlwaysListen());
   const [asrMode, setAsrModeState] = useState(storage.getASRMode());
   const [asrLanguage, setAsrLanguageState] = useState(storage.getASRLanguage() || '');
@@ -100,10 +102,32 @@ export const TTSSection: React.FC = () => {
   const setTtsEmotionAlpha = (v: number) => { setTtsEmotionAlphaState(v); storage.setTTSEmotionAlpha(v); };
   const setTtsUseEmotionText = (v: boolean) => { setTtsUseEmotionTextState(v); storage.setTTSUseEmotionText(v); };
 
+  const setSelectedMicId = (deviceId: string) => {
+    setSelectedMicIdState(deviceId);
+    if (deviceId) {
+      storage.setASRDeviceId(deviceId);
+      useMicStore.getState().selectDevice(deviceId);
+    }
+  };
+
   useEffect(() => {
     loadBackends();
     apiClient.getASRModels()
       .then((models) => setAvailableModels(models.map((m) => ({ id: m.id, name: m.name }))))
+      .catch(() => {});
+    // Load mic devices
+    navigator.mediaDevices.getUserMedia({ audio: true })
+      .then((stream) => {
+        stream.getTracks().forEach((t) => t.stop());
+        return navigator.mediaDevices.enumerateDevices();
+      })
+      .then((devices) => {
+        setMicDevices(
+          devices
+            .filter((d) => d.kind === 'audioinput')
+            .map((d) => ({ deviceId: d.deviceId, label: d.label || `Microphone ${d.deviceId.slice(0, 8)}` }))
+        );
+      })
       .catch(() => {});
   }, [loadBackends]);
 
@@ -139,6 +163,27 @@ export const TTSSection: React.FC = () => {
         <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
           Keep microphone active to detect trigger words or push-to-talk (Ctrl+Space). Disable to save resources.
         </Typography>
+      </Box>
+
+      {/* Microphone Selection */}
+      <Box sx={{ mb: 3 }}>
+        <FormControl fullWidth size="small">
+          <InputLabel>Microphone</InputLabel>
+          <Select
+            value={selectedMicId}
+            label="Microphone"
+            onChange={(e: SelectChangeEvent) => setSelectedMicId(e.target.value)}
+          >
+            <MenuItem value="">
+              <em>Default</em>
+            </MenuItem>
+            {micDevices.map((d) => (
+              <MenuItem key={d.deviceId} value={d.deviceId}>
+                {d.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
       </Box>
 
       {/* ASR Mode */}

--- a/src/components/settings/VoiceSection.tsx
+++ b/src/components/settings/VoiceSection.tsx
@@ -52,16 +52,27 @@ export const VoiceSection: React.FC = () => {
     localStorage.setItem('kurisu_speaker_device_id', deviceId);
   };
 
+  // Pause listening while on this page to free the mic for device enumeration
+  useEffect(() => {
+    const mic = useMicStore.getState();
+    const wasListening = mic.status !== 'idle';
+    if (wasListening) mic.stopListening();
+    return () => {
+      // Restart if always-listen is enabled
+      if (storage.getASRAlwaysListen()) {
+        useMicStore.getState().startListening();
+      }
+    };
+  }, []);
+
   useEffect(() => {
     const loadDevices = async () => {
-      // Request mic permission for device labels — skip if already listening (permission granted)
-      if (useMicStore.getState().status === 'idle') {
-        try {
-          const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-          stream.getTracks().forEach((t) => t.stop());
-        } catch {
-          // Permission may already be granted or denied
-        }
+      // Request mic permission to get device labels
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        stream.getTracks().forEach((t) => t.stop());
+      } catch {
+        // Permission may already be granted or denied
       }
       try {
         const devices = await navigator.mediaDevices.enumerateDevices();

--- a/src/components/settings/VoiceSection.tsx
+++ b/src/components/settings/VoiceSection.tsx
@@ -53,13 +53,16 @@ export const VoiceSection: React.FC = () => {
   };
 
   useEffect(() => {
-    // Request mic permission to get device labels, then enumerate
-    navigator.mediaDevices.getUserMedia({ audio: true })
-      .then((stream) => {
+    const loadDevices = async () => {
+      // Request mic permission to get device labels (may already be granted)
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
         stream.getTracks().forEach((t) => t.stop());
-        return navigator.mediaDevices.enumerateDevices();
-      })
-      .then((devices) => {
+      } catch {
+        // Permission may already be granted or denied — continue to enumerate
+      }
+      try {
+        const devices = await navigator.mediaDevices.enumerateDevices();
         setMicDevices(
           devices
             .filter((d) => d.kind === 'audioinput')
@@ -70,8 +73,11 @@ export const VoiceSection: React.FC = () => {
             .filter((d) => d.kind === 'audiooutput')
             .map((d) => ({ deviceId: d.deviceId, label: d.label || `Speaker ${d.deviceId.slice(0, 8)}` }))
         );
-      })
-      .catch(() => {});
+      } catch (err) {
+        console.error('Failed to enumerate devices:', err);
+      }
+    };
+    loadDevices();
   }, []);
 
   return (

--- a/src/components/settings/VoiceSection.tsx
+++ b/src/components/settings/VoiceSection.tsx
@@ -9,6 +9,7 @@ import {
   FormControlLabel,
   Switch,
   Divider,
+  Button,
   SelectChangeEvent,
 } from '@mui/material';
 import { storage } from '../../utils/storage';
@@ -27,6 +28,8 @@ export const VoiceSection: React.FC = () => {
     localStorage.getItem('kurisu_speaker_device_id') || ''
   );
   const [alwaysListen, setAlwaysListenState] = useState(storage.getASRAlwaysListen());
+  const [pttKeyLabel, setPttKeyLabel] = useState(storage.getPTTKeyLabel() || 'Not set');
+  const [capturing, setCapturing] = useState(false);
 
   const setAlwaysListen = (v: boolean) => {
     setAlwaysListenState(v);
@@ -50,6 +53,42 @@ export const VoiceSection: React.FC = () => {
   const setSelectedSpeakerId = (deviceId: string) => {
     setSelectedSpeakerIdState(deviceId);
     localStorage.setItem('kurisu_speaker_device_id', deviceId);
+  };
+
+  const electron = (window as any).electron;
+
+  // Send stored PTT keycode to main process on mount
+  useEffect(() => {
+    const keycode = storage.getPTTKeycode();
+    electron?.ptt?.setKeycode(keycode);
+  }, []);
+
+  // Listen for captured key from main process
+  useEffect(() => {
+    if (!electron?.ptt?.onKeyCaptured) return;
+    const cleanup = electron.ptt.onKeyCaptured((keycode: number) => {
+      setCapturing(false);
+      setPttKeyLabel(`Key ${keycode}`);
+      storage.setPTTKeycode(keycode);
+      storage.setPTTKeyLabel(`Key ${keycode}`);
+      electron.ptt.setKeycode(keycode);
+    });
+    return cleanup;
+  }, []);
+
+  const startCapture = () => {
+    setCapturing(true);
+    setPttKeyLabel('Press any key...');
+    electron?.ptt?.startCapture();
+  };
+
+  const clearShortcut = () => {
+    setCapturing(false);
+    setPttKeyLabel('Not set');
+    storage.setPTTKeycode(null);
+    storage.setPTTKeyLabel('');
+    electron?.ptt?.setKeycode(null);
+    electron?.ptt?.stopCapture();
   };
 
   // Pause listening while on this page to free the mic for device enumeration
@@ -131,7 +170,34 @@ export const VoiceSection: React.FC = () => {
           label="Always listen"
         />
         <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-          Keep microphone active to detect trigger words or push-to-talk (Ctrl+Space).
+          Keep microphone active to detect trigger words or push-to-talk.
+        </Typography>
+      </Box>
+
+      {/* PTT Shortcut */}
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>Push-to-talk shortcut</Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Box sx={{
+            px: 2, py: 1, borderRadius: 1,
+            border: '1px solid',
+            borderColor: capturing ? 'primary.main' : 'divider',
+            bgcolor: capturing ? 'action.selected' : 'background.paper',
+            minWidth: 120, textAlign: 'center',
+          }}>
+            <Typography variant="body2" color={capturing ? 'primary.main' : 'text.secondary'}>
+              {pttKeyLabel}
+            </Typography>
+          </Box>
+          <Button size="small" variant="outlined" onClick={startCapture} disabled={capturing}>
+            {capturing ? 'Listening...' : 'Set key'}
+          </Button>
+          <Button size="small" color="error" onClick={clearShortcut}>
+            Clear
+          </Button>
+        </Box>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+          Double-press this key to toggle voice interaction. Works even when the app is not focused.
         </Typography>
       </Box>
 

--- a/src/components/settings/VoiceSection.tsx
+++ b/src/components/settings/VoiceSection.tsx
@@ -54,12 +54,14 @@ export const VoiceSection: React.FC = () => {
 
   useEffect(() => {
     const loadDevices = async () => {
-      // Request mic permission to get device labels (may already be granted)
-      try {
-        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-        stream.getTracks().forEach((t) => t.stop());
-      } catch {
-        // Permission may already be granted or denied — continue to enumerate
+      // Request mic permission for device labels — skip if already listening (permission granted)
+      if (useMicStore.getState().status === 'idle') {
+        try {
+          const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+          stream.getTracks().forEach((t) => t.stop());
+        } catch {
+          // Permission may already be granted or denied
+        }
       }
       try {
         const devices = await navigator.mediaDevices.enumerateDevices();

--- a/src/components/settings/VoiceSection.tsx
+++ b/src/components/settings/VoiceSection.tsx
@@ -1,0 +1,145 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Typography,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  FormControlLabel,
+  Switch,
+  Divider,
+  SelectChangeEvent,
+} from '@mui/material';
+import { storage } from '../../utils/storage';
+import { useMicStore } from '../../store/micStore';
+
+interface AudioDevice {
+  deviceId: string;
+  label: string;
+}
+
+export const VoiceSection: React.FC = () => {
+  const [micDevices, setMicDevices] = useState<AudioDevice[]>([]);
+  const [speakerDevices, setSpeakerDevices] = useState<AudioDevice[]>([]);
+  const [selectedMicId, setSelectedMicIdState] = useState(storage.getASRDeviceId() || '');
+  const [selectedSpeakerId, setSelectedSpeakerIdState] = useState(
+    localStorage.getItem('kurisu_speaker_device_id') || ''
+  );
+  const [alwaysListen, setAlwaysListenState] = useState(storage.getASRAlwaysListen());
+
+  const setAlwaysListen = (v: boolean) => {
+    setAlwaysListenState(v);
+    storage.setASRAlwaysListen(v);
+    const mic = useMicStore.getState();
+    if (v && mic.status === 'idle') {
+      mic.startListening();
+    } else if (!v && mic.status !== 'idle') {
+      mic.stopListening();
+    }
+  };
+
+  const setSelectedMicId = (deviceId: string) => {
+    setSelectedMicIdState(deviceId);
+    if (deviceId) {
+      storage.setASRDeviceId(deviceId);
+      useMicStore.getState().selectDevice(deviceId);
+    }
+  };
+
+  const setSelectedSpeakerId = (deviceId: string) => {
+    setSelectedSpeakerIdState(deviceId);
+    localStorage.setItem('kurisu_speaker_device_id', deviceId);
+  };
+
+  useEffect(() => {
+    // Request mic permission to get device labels, then enumerate
+    navigator.mediaDevices.getUserMedia({ audio: true })
+      .then((stream) => {
+        stream.getTracks().forEach((t) => t.stop());
+        return navigator.mediaDevices.enumerateDevices();
+      })
+      .then((devices) => {
+        setMicDevices(
+          devices
+            .filter((d) => d.kind === 'audioinput')
+            .map((d) => ({ deviceId: d.deviceId, label: d.label || `Microphone ${d.deviceId.slice(0, 8)}` }))
+        );
+        setSpeakerDevices(
+          devices
+            .filter((d) => d.kind === 'audiooutput')
+            .map((d) => ({ deviceId: d.deviceId, label: d.label || `Speaker ${d.deviceId.slice(0, 8)}` }))
+        );
+      })
+      .catch(() => {});
+  }, []);
+
+  return (
+    <Box sx={{ maxWidth: 700 }}>
+      <Typography variant="h3" sx={{ mb: 3 }}>Voice</Typography>
+
+      {/* Microphone */}
+      <Typography variant="h6" sx={{ mb: 2 }}>Microphone</Typography>
+
+      <Box sx={{ mb: 3 }}>
+        <FormControl fullWidth size="small">
+          <InputLabel>Input device</InputLabel>
+          <Select
+            value={selectedMicId}
+            label="Input device"
+            onChange={(e: SelectChangeEvent) => setSelectedMicId(e.target.value)}
+          >
+            <MenuItem value="">
+              <em>Default</em>
+            </MenuItem>
+            {micDevices.map((d) => (
+              <MenuItem key={d.deviceId} value={d.deviceId}>
+                {d.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+
+      <Box sx={{ mb: 3 }}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={alwaysListen}
+              onChange={(e) => setAlwaysListen(e.target.checked)}
+            />
+          }
+          label="Always listen"
+        />
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+          Keep microphone active to detect trigger words or push-to-talk (Ctrl+Space).
+        </Typography>
+      </Box>
+
+      <Divider sx={{ mb: 3 }} />
+
+      {/* Speaker */}
+      <Typography variant="h6" sx={{ mb: 2 }}>Speaker</Typography>
+
+      <Box sx={{ mb: 3 }}>
+        <FormControl fullWidth size="small">
+          <InputLabel>Output device</InputLabel>
+          <Select
+            value={selectedSpeakerId}
+            label="Output device"
+            onChange={(e: SelectChangeEvent) => setSelectedSpeakerId(e.target.value)}
+          >
+            <MenuItem value="">
+              <em>Default</em>
+            </MenuItem>
+            {speakerDevices.map((d) => (
+              <MenuItem key={d.deviceId} value={d.deviceId}>
+                {d.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+    </Box>
+  );
+};

--- a/src/hooks/useInteractiveASR.ts
+++ b/src/hooks/useInteractiveASR.ts
@@ -1,6 +1,8 @@
 import { useState, useEffect, useRef } from 'react';
 import { useMicStore } from '../store/micStore';
 import { useAgentStore } from '../store/agentStore';
+import { apiClient } from '../api/client';
+import { storage } from '../utils/storage';
 
 interface UseInteractiveASRParams {
   agentId: number | null;
@@ -42,6 +44,7 @@ export function useInteractiveASR({
   // ASR transcript handling
   useEffect(() => {
     if (!asrResult) return;
+    const processResult = async () => {
     if (asrResult.seq <= lastProcessedSeq.current) return;
     lastProcessedSeq.current = asrResult.seq;
     const asrTranscript = asrResult.text;
@@ -53,28 +56,57 @@ export function useInteractiveASR({
     const hasTrigger = triggerWord && asrTranscript.toLowerCase().includes(triggerWord.toLowerCase());
 
     if (state.interactionActive || hasTrigger) {
-      // Show transcript
-      setLastTranscript(asrTranscript);
-      if (lastTranscriptTimerRef.current) clearTimeout(lastTranscriptTimerRef.current);
-      lastTranscriptTimerRef.current = setTimeout(() => setLastTranscript(''), 3000);
-
       // Activate interaction if trigger word detected
       if (!state.interactionActive) activateInteraction();
 
+      // If fast mode detected trigger word, re-transcribe with full quality
+      let finalText = asrTranscript;
+      if (asrResult.fast && asrResult.audio && hasTrigger) {
+        try {
+          let language: string | undefined;
+          let model: string | undefined;
+          const asrMode = storage.getASRMode();
+          if (asrMode === 'routing') {
+            const modelMap = storage.getASRModelMap();
+            const mappedLanguages = modelMap.map((e) => e.language).filter((l) => !!l);
+            const detected = await apiClient.detectLanguage(
+              asrResult.audio,
+              mappedLanguages.length > 0 ? { languages: mappedLanguages } : undefined,
+            );
+            language = detected.language || undefined;
+            model = language ? storage.getASRModelForLanguage(language) : undefined;
+          } else {
+            const fixedModel = storage.getASRFixedModel();
+            if (fixedModel) model = fixedModel;
+          }
+          const full = await apiClient.transcribe(asrResult.audio, { language, model });
+          if (full.text.trim()) finalText = full.text.trim();
+        } catch {
+          // Fall back to fast-mode text
+        }
+      }
+
+      // Show transcript
+      setLastTranscript(finalText);
+      if (lastTranscriptTimerRef.current) clearTimeout(lastTranscriptTimerRef.current);
+      lastTranscriptTimerRef.current = setTimeout(() => setLastTranscript(''), 3000);
+
       // Auto-send
       if (isStreamingRef.current) {
-        pendingAutoSendRef.current = asrTranscript;
+        pendingAutoSendRef.current = finalText;
       } else {
         if (interactionTimerRef.current) {
           clearTimeout(interactionTimerRef.current);
           interactionTimerRef.current = null;
         }
-        handleSendText(asrTranscript);
+        handleSendText(finalText);
       }
     } else {
       // Not in interaction and no trigger word: fill chat input as dictation
       pushExternalDraft(asrTranscript);
     }
+    };
+    processResult();
   }, [asrResult]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Deactivate interaction when agent or conversation changes

--- a/src/hooks/useInteractiveASR.ts
+++ b/src/hooks/useInteractiveASR.ts
@@ -46,6 +46,8 @@ export function useInteractiveASR({
     const triggerWord = selectedAgent?.persona?.trigger_word?.trim();
     const hasTrigger = triggerWord && asrTranscript.toLowerCase().includes(triggerWord.toLowerCase());
 
+    console.log('[ASR]', { text: asrTranscript, agentId, triggerWord, hasTrigger, interactionActive: state.interactionActive });
+
     if (state.interactionActive || hasTrigger) {
       // Show transcript
       setLastTranscript(asrTranscript);

--- a/src/hooks/useInteractiveASR.ts
+++ b/src/hooks/useInteractiveASR.ts
@@ -42,11 +42,10 @@ export function useInteractiveASR({
     const asrTranscript = asrResult.text;
     const state = useMicStore.getState();
 
-    const selectedAgent = storeAgents.find(a => a.id === agentId);
-    const triggerWord = selectedAgent?.persona?.trigger_word?.trim();
+    // Use Administrator agent's persona trigger word
+    const adminAgent = storeAgents.find(a => a.is_system);
+    const triggerWord = adminAgent?.persona?.trigger_word?.trim();
     const hasTrigger = triggerWord && asrTranscript.toLowerCase().includes(triggerWord.toLowerCase());
-
-    console.log('[ASR]', { text: asrTranscript, agentId, triggerWord, hasTrigger, interactionActive: state.interactionActive });
 
     if (state.interactionActive || hasTrigger) {
       // Show transcript

--- a/src/hooks/useInteractiveASR.ts
+++ b/src/hooks/useInteractiveASR.ts
@@ -1,8 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useMicStore } from '../store/micStore';
 import { useAgentStore } from '../store/agentStore';
-import { apiClient } from '../api/client';
-import { storage } from '../utils/storage';
 
 interface UseInteractiveASRParams {
   agentId: number | null;
@@ -44,7 +42,6 @@ export function useInteractiveASR({
   // ASR transcript handling
   useEffect(() => {
     if (!asrResult) return;
-    const processResult = async () => {
     if (asrResult.seq <= lastProcessedSeq.current) return;
     lastProcessedSeq.current = asrResult.seq;
     const asrTranscript = asrResult.text;
@@ -56,57 +53,28 @@ export function useInteractiveASR({
     const hasTrigger = triggerWord && asrTranscript.toLowerCase().includes(triggerWord.toLowerCase());
 
     if (state.interactionActive || hasTrigger) {
-      // Activate interaction if trigger word detected
-      if (!state.interactionActive) activateInteraction();
-
-      // If fast mode detected trigger word, re-transcribe with full quality
-      let finalText = asrTranscript;
-      if (asrResult.fast && asrResult.audio && hasTrigger) {
-        try {
-          let language: string | undefined;
-          let model: string | undefined;
-          const asrMode = storage.getASRMode();
-          if (asrMode === 'routing') {
-            const modelMap = storage.getASRModelMap();
-            const mappedLanguages = modelMap.map((e) => e.language).filter((l) => !!l);
-            const detected = await apiClient.detectLanguage(
-              asrResult.audio,
-              mappedLanguages.length > 0 ? { languages: mappedLanguages } : undefined,
-            );
-            language = detected.language || undefined;
-            model = language ? storage.getASRModelForLanguage(language) : undefined;
-          } else {
-            const fixedModel = storage.getASRFixedModel();
-            if (fixedModel) model = fixedModel;
-          }
-          const full = await apiClient.transcribe(asrResult.audio, { language, model });
-          if (full.text.trim()) finalText = full.text.trim();
-        } catch {
-          // Fall back to fast-mode text
-        }
-      }
-
       // Show transcript
-      setLastTranscript(finalText);
+      setLastTranscript(asrTranscript);
       if (lastTranscriptTimerRef.current) clearTimeout(lastTranscriptTimerRef.current);
       lastTranscriptTimerRef.current = setTimeout(() => setLastTranscript(''), 3000);
 
+      // Activate interaction if trigger word detected
+      if (!state.interactionActive) activateInteraction();
+
       // Auto-send
       if (isStreamingRef.current) {
-        pendingAutoSendRef.current = finalText;
+        pendingAutoSendRef.current = asrTranscript;
       } else {
         if (interactionTimerRef.current) {
           clearTimeout(interactionTimerRef.current);
           interactionTimerRef.current = null;
         }
-        handleSendText(finalText);
+        handleSendText(asrTranscript);
       }
     } else {
       // Not in interaction and no trigger word: fill chat input as dictation
       pushExternalDraft(asrTranscript);
     }
-    };
-    processResult();
   }, [asrResult]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Deactivate interaction when agent or conversation changes

--- a/src/hooks/useInteractiveASR.ts
+++ b/src/hooks/useInteractiveASR.ts
@@ -8,6 +8,7 @@ interface UseInteractiveASRParams {
   isStreaming: boolean;
   isQueueActive: boolean;
   handleSendText: (text: string) => Promise<void>;
+  pushExternalDraft: (text: string) => void;
 }
 
 export function useInteractiveASR({
@@ -16,6 +17,7 @@ export function useInteractiveASR({
   isStreaming,
   isQueueActive,
   handleSendText,
+  pushExternalDraft,
 }: UseInteractiveASRParams) {
   const {
     status: asrStatus, result: asrResult,
@@ -63,8 +65,10 @@ export function useInteractiveASR({
         }
         handleSendText(asrTranscript);
       }
+    } else {
+      // Not in interaction and no trigger word: fill chat input as dictation
+      pushExternalDraft(asrTranscript);
     }
-    // If not active and no trigger word: ignore (background listening)
   }, [asrResult]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Deactivate interaction when agent or conversation changes

--- a/src/hooks/useInteractiveASR.ts
+++ b/src/hooks/useInteractiveASR.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useMicStore } from '../store/micStore';
 import { useAgentStore } from '../store/agentStore';
 
@@ -23,12 +23,9 @@ export function useInteractiveASR({
 }: UseInteractiveASRParams) {
   const {
     status: asrStatus, result: asrResult,
-    devices: asrDevices, loadDevices: loadAsrDevices, selectedDeviceId: asrDeviceId, selectDevice: selectAsrDevice,
-    startListening, stopListening,
     interactiveMode, enableInteractiveMode, disableInteractiveMode,
     interactionActive, activateInteraction, deactivateInteraction,
   } = useMicStore();
-  const [micMenuAnchor, setMicMenuAnchor] = useState<HTMLElement | null>(null);
   const storeAgents = useAgentStore(state => state.agents);
   const interactionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingAutoSendRef = useRef<string | null>(null);
@@ -149,44 +146,12 @@ export function useInteractiveASR({
     };
   }, []);
 
-  const handleMicToggle = useCallback(() => {
-    if (asrStatus === 'idle') {
-      startListening();
-    } else {
-      stopListening();
-    }
-  }, [asrStatus, startListening, stopListening]);
-
-  const handleMicContext = useCallback((e: React.MouseEvent<HTMLElement>) => {
-    e.preventDefault();
-    const anchor = e.currentTarget;
-    loadAsrDevices().then(() => {
-      setMicMenuAnchor(anchor);
-    });
-  }, [loadAsrDevices]);
-
-  const closeMicMenu = useCallback(() => {
-    setMicMenuAnchor(null);
-  }, []);
-
-  const selectAsrDeviceAndClose = useCallback((deviceId: string) => {
-    selectAsrDevice(deviceId);
-    setMicMenuAnchor(null);
-  }, [selectAsrDevice]);
-
   return {
     asrStatus,
-    asrDevices,
-    asrDeviceId,
-    micMenuAnchor,
     interactiveMode,
     interactionActive,
     lastTranscript,
     disableInteractiveMode,
     isQueueActive,
-    handleMicToggle,
-    handleMicContext,
-    closeMicMenu,
-    selectAsrDevice: selectAsrDeviceAndClose,
   };
 }

--- a/src/hooks/useInteractiveASR.ts
+++ b/src/hooks/useInteractiveASR.ts
@@ -36,9 +36,14 @@ export function useInteractiveASR({
     isStreamingRef.current = isStreaming;
   }, [isStreaming]);
 
+  // Guard: skip already-processed results (React StrictMode double-fires effects)
+  const lastProcessedSeq = useRef(0);
+
   // ASR transcript handling
   useEffect(() => {
     if (!asrResult) return;
+    if (asrResult.seq <= lastProcessedSeq.current) return;
+    lastProcessedSeq.current = asrResult.seq;
     const asrTranscript = asrResult.text;
     const state = useMicStore.getState();
 

--- a/src/hooks/useInteractiveASR.ts
+++ b/src/hooks/useInteractiveASR.ts
@@ -8,8 +8,6 @@ interface UseInteractiveASRParams {
   isStreaming: boolean;
   isQueueActive: boolean;
   handleSendText: (text: string) => Promise<void>;
-  pushExternalDraft: (text: string) => void;
-  clearExternalDraft: () => void;
 }
 
 export function useInteractiveASR({
@@ -18,29 +16,25 @@ export function useInteractiveASR({
   isStreaming,
   isQueueActive,
   handleSendText,
-  pushExternalDraft,
-  clearExternalDraft,
 }: UseInteractiveASRParams) {
   const {
     status: asrStatus, result: asrResult,
-    interactiveMode, enableInteractiveMode, disableInteractiveMode,
     interactionActive, activateInteraction, deactivateInteraction,
+    pttActive,
   } = useMicStore();
   const storeAgents = useAgentStore(state => state.agents);
   const interactionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingAutoSendRef = useRef<string | null>(null);
-  const ttsPlayedForResponseRef = useRef(false);
   const INTERACTION_IDLE_MS = 30_000;
   const [lastTranscript, setLastTranscript] = useState('');
   const lastTranscriptTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Keep a ref to isStreaming to avoid stale closures
   const isStreamingRef = useRef(false);
   useEffect(() => {
     isStreamingRef.current = isStreaming;
   }, [isStreaming]);
 
-  // ASR transcript handling: branch on interactive mode and interaction state
+  // ASR transcript handling
   useEffect(() => {
     if (!asrResult) return;
     const asrTranscript = asrResult.text;
@@ -50,45 +44,34 @@ export function useInteractiveASR({
     const triggerWord = selectedAgent?.persona?.trigger_word?.trim();
     const hasTrigger = triggerWord && asrTranscript.toLowerCase().includes(triggerWord.toLowerCase());
 
-    if (state.interactiveMode) {
-      // Interactive mode: always show transcript visually
+    if (state.interactionActive || hasTrigger) {
+      // Show transcript
       setLastTranscript(asrTranscript);
       if (lastTranscriptTimerRef.current) clearTimeout(lastTranscriptTimerRef.current);
       lastTranscriptTimerRef.current = setTimeout(() => setLastTranscript(''), 3000);
 
-      if (state.interactionActive || hasTrigger) {
-        // Interaction active or trigger word detected: auto-send
-        if (!state.interactionActive) activateInteraction();
+      // Activate interaction if trigger word detected
+      if (!state.interactionActive) activateInteraction();
 
-        if (isStreamingRef.current) {
-          pendingAutoSendRef.current = asrTranscript;
-        } else {
-          if (interactionTimerRef.current) {
-            clearTimeout(interactionTimerRef.current);
-            interactionTimerRef.current = null;
-          }
-          ttsPlayedForResponseRef.current = false;
-          handleSendText(asrTranscript);
+      // Auto-send
+      if (isStreamingRef.current) {
+        pendingAutoSendRef.current = asrTranscript;
+      } else {
+        if (interactionTimerRef.current) {
+          clearTimeout(interactionTimerRef.current);
+          interactionTimerRef.current = null;
         }
-      }
-      // If not active and no trigger word, show transcript without sending
-    } else {
-      // Typing mode: put text in input field (dictation)
-      pushExternalDraft(asrTranscript);
-      // Check trigger word, then enable interaction mode and auto-send
-      if (hasTrigger) {
-        enableInteractiveMode();
-        activateInteraction();
-        ttsPlayedForResponseRef.current = false;
-        handleSendText(asrTranscript).finally(() => clearExternalDraft());
+        handleSendText(asrTranscript);
       }
     }
-  }, [asrResult, clearExternalDraft, pushExternalDraft]); // eslint-disable-line react-hooks/exhaustive-deps
+    // If not active and no trigger word: ignore (background listening)
+  }, [asrResult]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Disable interactive mode when agent or conversation changes
+  // Deactivate interaction when agent or conversation changes
   useEffect(() => {
-    if (useMicStore.getState().interactiveMode) {
-      disableInteractiveMode();
+    const state = useMicStore.getState();
+    if (state.interactionActive) {
+      deactivateInteraction();
       if (interactionTimerRef.current) {
         clearTimeout(interactionTimerRef.current);
         interactionTimerRef.current = null;
@@ -97,46 +80,40 @@ export function useInteractiveASR({
     }
   }, [agentId, currentConversationId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Start a 30s idle timer after streaming and TTS finish; keep interactive mode enabled
+  // 30s idle timer — only for trigger word flow (not PTT)
   useEffect(() => {
-    if (!interactiveMode || !interactionActive) return;
-    // Timer starts when: not streaming AND TTS queue not active
+    if (!interactionActive || pttActive) return;
+
     if (!isStreaming && !isQueueActive) {
-      if (interactionTimerRef.current) {
-        clearTimeout(interactionTimerRef.current);
-      }
+      if (interactionTimerRef.current) clearTimeout(interactionTimerRef.current);
       interactionTimerRef.current = setTimeout(() => {
         deactivateInteraction();
         interactionTimerRef.current = null;
         pendingAutoSendRef.current = null;
       }, INTERACTION_IDLE_MS);
     } else {
-      // Still streaming or playing TTS, so clear the idle timer
       if (interactionTimerRef.current) {
         clearTimeout(interactionTimerRef.current);
         interactionTimerRef.current = null;
       }
     }
-  }, [interactiveMode, interactionActive, isStreaming, isQueueActive, deactivateInteraction]);
+  }, [interactionActive, pttActive, isStreaming, isQueueActive, deactivateInteraction]);
 
   // Handle pending auto-send when streaming finishes
   useEffect(() => {
     if (!isStreaming && pendingAutoSendRef.current) {
       const text = pendingAutoSendRef.current;
       pendingAutoSendRef.current = null;
-      ttsPlayedForResponseRef.current = false;
       handleSendText(text);
     }
   }, [isStreaming]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Clear UI state on interactive mode transitions
+  // Clear transcript when interaction ends
   useEffect(() => {
-    if (interactiveMode) {
-      clearExternalDraft();
-    } else {
+    if (!interactionActive) {
       setLastTranscript('');
     }
-  }, [interactiveMode, clearExternalDraft]);
+  }, [interactionActive]);
 
   // Cleanup timers on unmount
   useEffect(() => {
@@ -148,10 +125,9 @@ export function useInteractiveASR({
 
   return {
     asrStatus,
-    interactiveMode,
     interactionActive,
+    pttActive,
     lastTranscript,
-    disableInteractiveMode,
     isQueueActive,
   };
 }

--- a/src/services/appToolsHandler.ts
+++ b/src/services/appToolsHandler.ts
@@ -7,6 +7,7 @@
 
 import { apiClient } from '../api/client';
 import { useVisionStore } from '../store/visionStore';
+import { useMicStore } from '../store/micStore';
 import { useExplorerStore } from '../store/explorerStore';
 import { useLayoutStore } from '../store/layoutStore';
 import { refreshClientMCPServers } from './mcpService';
@@ -262,6 +263,15 @@ async function handleVisionStop(): Promise<ToolResult> {
   return ok('Vision pipeline stopped.');
 }
 
+// --- Voice interaction ---
+
+async function handleEndInteraction(): Promise<ToolResult> {
+  const mic = useMicStore.getState();
+  if (!mic.interactionActive) return ok('No active voice interaction.');
+  mic.deactivateInteraction();
+  return ok('Voice interaction ended.');
+}
+
 // --- UI control ---
 
 async function handleOpenFile(args: Record<string, unknown>): Promise<ToolResult> {
@@ -339,6 +349,7 @@ async function dispatch(name: string, args: Record<string, unknown>): Promise<To
     case 'app_list_tools': return handleListTools();
     case 'app_vision_start': return handleVisionStart(args);
     case 'app_vision_stop': return handleVisionStop();
+    case 'app_end_interaction': return handleEndInteraction();
     case 'app_open_file': return handleOpenFile(args);
     case 'app_open_folder': return handleOpenFolder(args);
     case 'app_get_open_files': return handleGetOpenFiles();

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -49,7 +49,9 @@ interface MicState {
 // Module-level VAD state (not in Zustand to avoid re-renders)
 let _vad: MicVAD | null = null;
 let _seq = 0;
-let _lastProbUpdate = 0;
+let _audioCtx: AudioContext | null = null;
+let _analyser: AnalyserNode | null = null;
+let _amplitudeInterval: ReturnType<typeof setInterval> | null = null;
 
 // Reusable audio elements for sound effects (avoids WebMediaPlayer leak)
 let _startSound: HTMLAudioElement | null = null;
@@ -91,8 +93,8 @@ export const useMicStore = create<MicState>((set, get) => ({
         onnxWASMBasePath: './vad/',
         model: 'legacy',
         startOnLoad: true,
-        getStream: async () =>
-          navigator.mediaDevices.getUserMedia({
+        getStream: async () => {
+          const stream = await navigator.mediaDevices.getUserMedia({
             audio: {
               deviceId: deviceId ? { exact: deviceId } : undefined,
               channelCount: 1,
@@ -100,14 +102,26 @@ export const useMicStore = create<MicState>((set, get) => ({
               autoGainControl: true,
               noiseSuppression: true,
             },
-          }),
-        onFrameProcessed: (probs: { isSpeech: number }) => {
-          // Throttle to ~5fps to avoid excessive re-renders
-          const now = Date.now();
-          if (now - _lastProbUpdate > 200) {
-            _lastProbUpdate = now;
-            set({ speechProbability: probs.isSpeech });
-          }
+          });
+          // Attach analyser for amplitude indicator
+          _audioCtx = new AudioContext();
+          const source = _audioCtx.createMediaStreamSource(stream);
+          _analyser = _audioCtx.createAnalyser();
+          _analyser.fftSize = 256;
+          source.connect(_analyser);
+          const dataArray = new Uint8Array(_analyser.fftSize);
+          _amplitudeInterval = setInterval(() => {
+            if (!_analyser) return;
+            _analyser.getByteTimeDomainData(dataArray);
+            let sum = 0;
+            for (let i = 0; i < dataArray.length; i++) {
+              const v = (dataArray[i] - 128) / 128;
+              sum += v * v;
+            }
+            const rms = Math.sqrt(sum / dataArray.length);
+            set({ speechProbability: Math.min(1, rms * 4) });
+          }, 200);
+          return stream;
         },
         onSpeechEnd: async (audio: Float32Array) => {
           // Skip audio too short to contain a trigger word (< 0.5s at 16kHz)
@@ -178,6 +192,8 @@ export const useMicStore = create<MicState>((set, get) => ({
   },
 
   stopListening: async () => {
+    if (_amplitudeInterval) { clearInterval(_amplitudeInterval); _amplitudeInterval = null; }
+    if (_audioCtx) { _audioCtx.close().catch(() => {}); _audioCtx = null; _analyser = null; }
     if (_vad) {
       await _vad.destroy();
       _vad = null;

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -19,6 +19,8 @@ export interface AudioDevice {
 export interface ASRResult {
   text: string;
   seq: number;
+  audio?: ArrayBuffer; // Raw PCM for re-transcription
+  fast?: boolean;      // Whether this was a fast-mode result
 }
 
 interface MicState {
@@ -178,7 +180,12 @@ export const useMicStore = create<MicState>((set, get) => ({
 
             if (response.text.trim()) {
               _seq += 1;
-              set({ result: { text: response.text.trim(), seq: _seq } });
+              set({ result: {
+                text: response.text.trim(),
+                seq: _seq,
+                audio: fast ? int16.buffer.slice(0) : undefined,
+                fast,
+              } });
             }
           } catch (err: any) {
             console.error('ASR transcription error:', err);

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -19,8 +19,6 @@ export interface AudioDevice {
 export interface ASRResult {
   text: string;
   seq: number;
-  audio?: ArrayBuffer; // Raw PCM for re-transcription
-  fast?: boolean;      // Whether this was a fast-mode result
 }
 
 interface MicState {
@@ -143,49 +141,36 @@ export const useMicStore = create<MicState>((set, get) => ({
           set({ status: 'processing' });
 
           try {
-            const { interactionActive } = get();
-
+            const asrMode = storage.getASRMode();
             let language: string | undefined;
             let model: string | undefined;
-            let initial_prompt: string | undefined;
-            let fast = false;
 
-            if (interactionActive) {
-              // Full quality: language detection + routing, no initial_prompt
-              const asrMode = storage.getASRMode();
-              if (asrMode === 'routing') {
-                const modelMap = storage.getASRModelMap();
-                const mappedLanguages = modelMap
-                  .map((e) => e.language)
-                  .filter((l) => !!l);
-                const detected = await apiClient.detectLanguage(
-                  int16.buffer,
-                  mappedLanguages.length > 0 ? { languages: mappedLanguages } : undefined,
-                );
-                language = detected.language || undefined;
-                model = language ? storage.getASRModelForLanguage(language) : undefined;
-              } else {
-                const fixedModel = storage.getASRFixedModel();
-                if (fixedModel) model = fixedModel;
-              }
+            if (asrMode === 'routing') {
+              const modelMap = storage.getASRModelMap();
+              const mappedLanguages = modelMap
+                .map((e) => e.language)
+                .filter((l) => !!l);
+              const detected = await apiClient.detectLanguage(
+                int16.buffer,
+                mappedLanguages.length > 0 ? { languages: mappedLanguages } : undefined,
+              );
+              language = detected.language || undefined;
+              model = language ? storage.getASRModelForLanguage(language) : undefined;
             } else {
-              // Background listening: fast mode + initial_prompt for trigger word detection
-              fast = true;
-              const { agents, selectedAgentId } = useAgentStore.getState();
-              const selectedAgent = agents.find((a) => a.id === selectedAgentId);
-              initial_prompt = selectedAgent?.persona?.trigger_word?.trim() || undefined;
+              const fixedModel = storage.getASRFixedModel();
+              if (fixedModel) model = fixedModel;
             }
 
-            const response = await apiClient.transcribe(int16.buffer, { language, model, initial_prompt, fast });
+            // Always send trigger word as initial_prompt to bias recognition
+            const { agents, selectedAgentId } = useAgentStore.getState();
+            const selectedAgent = agents.find((a) => a.id === selectedAgentId);
+            const initial_prompt = selectedAgent?.persona?.trigger_word?.trim() || undefined;
+
+            const response = await apiClient.transcribe(int16.buffer, { language, model, initial_prompt });
 
             if (response.text.trim()) {
               _seq += 1;
-              set({ result: {
-                text: response.text.trim(),
-                seq: _seq,
-                audio: fast ? int16.buffer.slice(0) : undefined,
-                fast,
-              } });
+              set({ result: { text: response.text.trim(), seq: _seq } });
             }
           } catch (err: any) {
             console.error('ASR transcription error:', err);

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -141,38 +141,40 @@ export const useMicStore = create<MicState>((set, get) => ({
           set({ status: 'processing' });
 
           try {
-            const asrMode = storage.getASRMode();
+            const { interactionActive } = get();
 
             let language: string | undefined;
             let model: string | undefined;
-
-            if (asrMode === 'routing') {
-              // Only detect among languages that have a model mapping
-              const modelMap = storage.getASRModelMap();
-              const mappedLanguages = modelMap
-                .map((e) => e.language)
-                .filter((l) => !!l);
-              const detected = await apiClient.detectLanguage(
-                int16.buffer,
-                mappedLanguages.length > 0 ? { languages: mappedLanguages } : undefined,
-              );
-              language = detected.language || undefined;
-              model = language ? storage.getASRModelForLanguage(language) : undefined;
-            } else {
-              const fixedModel = storage.getASRFixedModel();
-              if (fixedModel) model = fixedModel;
-            }
-
-            // Only bias with trigger word during active interaction (not background listening)
-            const { interactionActive } = get();
             let initial_prompt: string | undefined;
+            let fast = false;
+
             if (interactionActive) {
+              // Full quality: language detection + routing + initial_prompt
+              const asrMode = storage.getASRMode();
+              if (asrMode === 'routing') {
+                const modelMap = storage.getASRModelMap();
+                const mappedLanguages = modelMap
+                  .map((e) => e.language)
+                  .filter((l) => !!l);
+                const detected = await apiClient.detectLanguage(
+                  int16.buffer,
+                  mappedLanguages.length > 0 ? { languages: mappedLanguages } : undefined,
+                );
+                language = detected.language || undefined;
+                model = language ? storage.getASRModelForLanguage(language) : undefined;
+              } else {
+                const fixedModel = storage.getASRFixedModel();
+                if (fixedModel) model = fixedModel;
+              }
               const { agents, selectedAgentId } = useAgentStore.getState();
               const selectedAgent = agents.find((a) => a.id === selectedAgentId);
               initial_prompt = selectedAgent?.persona?.trigger_word?.trim() || undefined;
+            } else {
+              // Background listening: fast mode, default model, just detect trigger word
+              fast = true;
             }
 
-            const response = await apiClient.transcribe(int16.buffer, { language, model, initial_prompt });
+            const response = await apiClient.transcribe(int16.buffer, { language, model, initial_prompt, fast });
 
             if (response.text.trim()) {
               _seq += 1;

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -252,11 +252,13 @@ export const useMicStore = create<MicState>((set, get) => ({
   activateInteraction: () => {
     if (get().interactionActive) return;
     set({ interactionActive: true });
+    playStartSound();
   },
 
   deactivateInteraction: () => {
     if (!get().interactionActive) return;
     set({ interactionActive: false, pttActive: false });
+    playStopSound();
   },
 
   activatePTT: () => {

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -252,13 +252,11 @@ export const useMicStore = create<MicState>((set, get) => ({
   activateInteraction: () => {
     if (get().interactionActive) return;
     set({ interactionActive: true });
-    playStartSound();
   },
 
   deactivateInteraction: () => {
     if (!get().interactionActive) return;
     set({ interactionActive: false, pttActive: false });
-    playStopSound();
   },
 
   activatePTT: () => {

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -142,8 +142,6 @@ export const useMicStore = create<MicState>((set, get) => ({
 
           try {
             const asrMode = storage.getASRMode();
-            const { interactiveMode, interactionActive } = get();
-            const mode = interactiveMode && !interactionActive ? 'fast' : undefined;
 
             let language: string | undefined;
             let model: string | undefined;
@@ -171,7 +169,7 @@ export const useMicStore = create<MicState>((set, get) => ({
             const triggerWord = selectedAgent?.persona?.trigger_word?.trim();
             const initial_prompt = triggerWord || undefined;
 
-            const response = await apiClient.transcribe(int16.buffer, { language, mode, model, initial_prompt });
+            const response = await apiClient.transcribe(int16.buffer, { language, model, initial_prompt });
 
             if (response.text.trim()) {
               _seq += 1;

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -149,7 +149,7 @@ export const useMicStore = create<MicState>((set, get) => ({
             let fast = false;
 
             if (interactionActive) {
-              // Full quality: language detection + routing + initial_prompt
+              // Full quality: language detection + routing, no initial_prompt
               const asrMode = storage.getASRMode();
               if (asrMode === 'routing') {
                 const modelMap = storage.getASRModelMap();
@@ -166,12 +166,12 @@ export const useMicStore = create<MicState>((set, get) => ({
                 const fixedModel = storage.getASRFixedModel();
                 if (fixedModel) model = fixedModel;
               }
+            } else {
+              // Background listening: fast mode + initial_prompt for trigger word detection
+              fast = true;
               const { agents, selectedAgentId } = useAgentStore.getState();
               const selectedAgent = agents.find((a) => a.id === selectedAgentId);
               initial_prompt = selectedAgent?.persona?.trigger_word?.trim() || undefined;
-            } else {
-              // Background listening: fast mode, default model, just detect trigger word
-              fast = true;
             }
 
             const response = await apiClient.transcribe(int16.buffer, { language, model, initial_prompt, fast });

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -53,6 +53,7 @@ interface MicState {
 // Module-level VAD state (not in Zustand to avoid re-renders)
 let _vad: MicVAD | null = null;
 let _seq = 0;
+let _processing = false;
 let _audioCtx: AudioContext | null = null;
 let _analyser: AnalyserNode | null = null;
 let _amplitudeRaf = 0;
@@ -131,6 +132,9 @@ export const useMicStore = create<MicState>((set, get) => ({
         onSpeechEnd: async (audio: Float32Array) => {
           // Skip audio too short to contain a trigger word (< 0.5s at 16kHz)
           if (audio.length < 8000) return;
+          // Prevent concurrent processing (React StrictMode can double-fire)
+          if (_processing) return;
+          _processing = true;
 
           const int16 = new Int16Array(audio.length);
           for (let i = 0; i < audio.length; i++) {
@@ -177,6 +181,7 @@ export const useMicStore = create<MicState>((set, get) => ({
             set({ error: err.message || 'Transcription failed' });
           }
 
+          _processing = false;
           if (get().status !== 'idle') {
             set({ status: 'listening' });
           }

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -49,6 +49,7 @@ interface MicState {
 // Module-level VAD state (not in Zustand to avoid re-renders)
 let _vad: MicVAD | null = null;
 let _seq = 0;
+let _lastProbUpdate = 0;
 
 // Reusable audio elements for sound effects (avoids WebMediaPlayer leak)
 let _startSound: HTMLAudioElement | null = null;
@@ -101,7 +102,12 @@ export const useMicStore = create<MicState>((set, get) => ({
             },
           }),
         onFrameProcessed: (probs: { isSpeech: number }) => {
-          set({ speechProbability: probs.isSpeech });
+          // Throttle to ~5fps to avoid excessive re-renders
+          const now = Date.now();
+          if (now - _lastProbUpdate > 200) {
+            _lastProbUpdate = now;
+            set({ speechProbability: probs.isSpeech });
+          }
         },
         onSpeechEnd: async (audio: Float32Array) => {
           // Skip audio too short to contain a trigger word (< 0.5s at 16kHz)

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -30,6 +30,7 @@ interface MicState {
   interactiveMode: boolean;
   interactionActive: boolean;
   pttActive: boolean;
+  speechProbability: number;
 
   // Actions
   startListening: () => Promise<void>;
@@ -74,6 +75,7 @@ export const useMicStore = create<MicState>((set, get) => ({
   interactiveMode: false,
   interactionActive: false,
   pttActive: false,
+  speechProbability: 0,
 
   startListening: async () => {
     // Guard: skip if already listening or initializing
@@ -98,6 +100,9 @@ export const useMicStore = create<MicState>((set, get) => ({
               noiseSuppression: true,
             },
           }),
+        onFrameProcessed: (probs: { isSpeech: number }) => {
+          set({ speechProbability: probs.isSpeech });
+        },
         onSpeechEnd: async (audio: Float32Array) => {
           // Skip audio too short to contain a trigger word (< 0.5s at 16kHz)
           if (audio.length < 8000) return;
@@ -171,7 +176,7 @@ export const useMicStore = create<MicState>((set, get) => ({
       await _vad.destroy();
       _vad = null;
     }
-    set({ status: 'idle' });
+    set({ status: 'idle', speechProbability: 0 });
   },
 
   loadDevices: async () => {

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -6,6 +6,11 @@ import { useAgentStore } from './agentStore';
 
 export type ASRStatus = 'idle' | 'listening' | 'processing';
 
+/** Read real-time mic amplitude (0-1) outside of React state to avoid re-renders. */
+export function getMicAmplitude(): number {
+  return _amplitudeData.current;
+}
+
 export interface AudioDevice {
   deviceId: string;
   label: string;
@@ -30,7 +35,6 @@ interface MicState {
   interactiveMode: boolean;
   interactionActive: boolean;
   pttActive: boolean;
-  speechProbability: number;
 
   // Actions
   startListening: () => Promise<void>;
@@ -51,7 +55,8 @@ let _vad: MicVAD | null = null;
 let _seq = 0;
 let _audioCtx: AudioContext | null = null;
 let _analyser: AnalyserNode | null = null;
-let _amplitudeInterval: ReturnType<typeof setInterval> | null = null;
+let _amplitudeRaf = 0;
+const _amplitudeData = { current: 0 }; // Module-level, read by components via getAmplitude()
 
 // Reusable audio elements for sound effects (avoids WebMediaPlayer leak)
 let _startSound: HTMLAudioElement | null = null;
@@ -78,7 +83,6 @@ export const useMicStore = create<MicState>((set, get) => ({
   interactiveMode: false,
   interactionActive: false,
   pttActive: false,
-  speechProbability: 0,
 
   startListening: async () => {
     // Guard: skip if already listening or initializing
@@ -110,7 +114,7 @@ export const useMicStore = create<MicState>((set, get) => ({
           _analyser.fftSize = 256;
           source.connect(_analyser);
           const dataArray = new Uint8Array(_analyser.fftSize);
-          _amplitudeInterval = setInterval(() => {
+          const updateAmplitude = () => {
             if (!_analyser) return;
             _analyser.getByteTimeDomainData(dataArray);
             let sum = 0;
@@ -118,9 +122,10 @@ export const useMicStore = create<MicState>((set, get) => ({
               const v = (dataArray[i] - 128) / 128;
               sum += v * v;
             }
-            const rms = Math.sqrt(sum / dataArray.length);
-            set({ speechProbability: Math.min(1, rms * 4) });
-          }, 200);
+            _amplitudeData.current = Math.min(1, Math.sqrt(sum / dataArray.length) * 4);
+            _amplitudeRaf = requestAnimationFrame(updateAmplitude);
+          };
+          _amplitudeRaf = requestAnimationFrame(updateAmplitude);
           return stream;
         },
         onSpeechEnd: async (audio: Float32Array) => {
@@ -192,13 +197,14 @@ export const useMicStore = create<MicState>((set, get) => ({
   },
 
   stopListening: async () => {
-    if (_amplitudeInterval) { clearInterval(_amplitudeInterval); _amplitudeInterval = null; }
+    if (_amplitudeRaf) { cancelAnimationFrame(_amplitudeRaf); _amplitudeRaf = 0; }
+    _amplitudeData.current = 0;
     if (_audioCtx) { _audioCtx.close().catch(() => {}); _audioCtx = null; _analyser = null; }
     if (_vad) {
       await _vad.destroy();
       _vad = null;
     }
-    set({ status: 'idle', speechProbability: 0 });
+    set({ status: 'idle' });
   },
 
   loadDevices: async () => {

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -29,6 +29,7 @@ interface MicState {
   // Interactive mode (call bar UI) + interaction active (auto-send without trigger word)
   interactiveMode: boolean;
   interactionActive: boolean;
+  pttActive: boolean;
 
   // Actions
   startListening: () => Promise<void>;
@@ -39,6 +40,9 @@ interface MicState {
   disableInteractiveMode: () => void;
   activateInteraction: () => void;
   deactivateInteraction: () => void;
+  activatePTT: () => void;
+  deactivatePTT: () => void;
+  initAlwaysListen: () => void;
 }
 
 // Module-level VAD state (not in Zustand to avoid re-renders)
@@ -69,6 +73,7 @@ export const useMicStore = create<MicState>((set, get) => ({
   selectedDeviceId: storage.getASRDeviceId(),
   interactiveMode: false,
   interactionActive: false,
+  pttActive: false,
 
   startListening: async () => {
     // Guard: skip if already listening or initializing
@@ -221,7 +226,25 @@ export const useMicStore = create<MicState>((set, get) => ({
 
   deactivateInteraction: () => {
     if (!get().interactionActive) return;
-    set({ interactionActive: false });
+    set({ interactionActive: false, pttActive: false });
     playStopSound();
+  },
+
+  activatePTT: () => {
+    if (get().pttActive) return;
+    set({ interactionActive: true, pttActive: true });
+    playStartSound();
+  },
+
+  deactivatePTT: () => {
+    if (!get().pttActive) return;
+    set({ interactionActive: false, pttActive: false });
+    playStopSound();
+  },
+
+  initAlwaysListen: () => {
+    if (!storage.getASRAlwaysListen()) return;
+    if (get().status !== 'idle') return;
+    get().startListening();
   },
 }));

--- a/src/store/micStore.ts
+++ b/src/store/micStore.ts
@@ -163,11 +163,14 @@ export const useMicStore = create<MicState>((set, get) => ({
               if (fixedModel) model = fixedModel;
             }
 
-            // Pass selected persona's trigger word to bias recognition
-            const { agents, selectedAgentId } = useAgentStore.getState();
-            const selectedAgent = agents.find((a) => a.id === selectedAgentId);
-            const triggerWord = selectedAgent?.persona?.trigger_word?.trim();
-            const initial_prompt = triggerWord || undefined;
+            // Only bias with trigger word during active interaction (not background listening)
+            const { interactionActive } = get();
+            let initial_prompt: string | undefined;
+            if (interactionActive) {
+              const { agents, selectedAgentId } = useAgentStore.getState();
+              const selectedAgent = agents.find((a) => a.id === selectedAgentId);
+              initial_prompt = selectedAgent?.persona?.trigger_word?.trim() || undefined;
+            }
 
             const response = await apiClient.transcribe(int16.buffer, { language, model, initial_prompt });
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -18,6 +18,7 @@ const STORAGE_KEYS = {
   SELECTED_AGENT_ID: 'kurisu_selected_agent_id',
   AGENT_CONVERSATIONS: 'kurisu_agent_conversations',
   ASR_LANGUAGE: 'kurisu_asr_language',
+  ASR_ALWAYS_LISTEN: 'kurisu_asr_always_listen',
   ASR_MODE: 'kurisu_asr_mode',
   ASR_FIXED_MODEL: 'kurisu_asr_fixed_model',
   ASR_MODEL_MAP: 'kurisu_asr_model_map',
@@ -407,6 +408,24 @@ export const storage = {
       localStorage.removeItem(STORAGE_KEYS.ASR_LANGUAGE);
     } catch (error) {
       console.error('Failed to clear ASR language:', error);
+    }
+  },
+
+  /** Always-listen: keep mic active for trigger word detection. Default true. */
+  getASRAlwaysListen(): boolean {
+    try {
+      const v = localStorage.getItem(STORAGE_KEYS.ASR_ALWAYS_LISTEN);
+      return v === 'true';
+    } catch {
+      return true;
+    }
+  },
+
+  setASRAlwaysListen(enabled: boolean): void {
+    try {
+      localStorage.setItem(STORAGE_KEYS.ASR_ALWAYS_LISTEN, enabled.toString());
+    } catch (error) {
+      console.error('Failed to save ASR always-listen:', error);
     }
   },
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -19,6 +19,8 @@ const STORAGE_KEYS = {
   AGENT_CONVERSATIONS: 'kurisu_agent_conversations',
   ASR_LANGUAGE: 'kurisu_asr_language',
   ASR_ALWAYS_LISTEN: 'kurisu_asr_always_listen',
+  PTT_KEYCODE: 'kurisu_ptt_keycode',
+  PTT_KEY_LABEL: 'kurisu_ptt_key_label',
   ASR_MODE: 'kurisu_asr_mode',
   ASR_FIXED_MODEL: 'kurisu_asr_fixed_model',
   ASR_MODEL_MAP: 'kurisu_asr_model_map',
@@ -409,6 +411,40 @@ export const storage = {
     } catch (error) {
       console.error('Failed to clear ASR language:', error);
     }
+  },
+
+  /** PTT keycode (uiohook keycode number) */
+  getPTTKeycode(): number | null {
+    try {
+      const v = localStorage.getItem(STORAGE_KEYS.PTT_KEYCODE);
+      return v ? parseInt(v, 10) : null;
+    } catch {
+      return null;
+    }
+  },
+
+  setPTTKeycode(keycode: number | null): void {
+    try {
+      if (keycode !== null) {
+        localStorage.setItem(STORAGE_KEYS.PTT_KEYCODE, keycode.toString());
+      } else {
+        localStorage.removeItem(STORAGE_KEYS.PTT_KEYCODE);
+      }
+    } catch {}
+  },
+
+  getPTTKeyLabel(): string {
+    try {
+      return localStorage.getItem(STORAGE_KEYS.PTT_KEY_LABEL) || '';
+    } catch {
+      return '';
+    }
+  },
+
+  setPTTKeyLabel(label: string): void {
+    try {
+      localStorage.setItem(STORAGE_KEYS.PTT_KEY_LABEL, label);
+    } catch {}
   },
 
   /** Always-listen: keep mic active for trigger word detection. Default true. */


### PR DESCRIPTION
## Summary
- Remove mic dictation button and phone toggle — replaced by always-listening mode
- **Always-listen**: mic (VAD) runs in background when enabled in Voice settings
- **Two activation flows**:
  - Trigger word: say persona name → call bar appears, multi-turn with 30s idle timeout
  - Push-to-talk: hold Ctrl+Space → speak → release (or configurable key via uiohook-napi)
- **Headset support**: configurable global shortcut via uiohook-napi, double-press to toggle, works unfocused
- **Voice settings page**: mic/speaker device selection, always-listen toggle, PTT shortcut config
- **Agent tool**: `app_end_interaction` lets the agent end voice sessions on farewell
- Mic indicator with real-time amplitude (green glow via Web Audio AnalyserNode + rAF)
- `initial_prompt` on all requests for trigger word bias
- `without_timestamps` for faster transcription
- Processing lock to prevent double requests from React StrictMode

## Test plan
- [ ] Enable "Always listen" in Voice settings → mic starts, green indicator shows
- [ ] Say trigger word → call bar appears, message auto-sent
- [ ] Hold Ctrl+Space → call bar, speak, release → sends, call bar hides
- [ ] Set custom PTT key in Voice settings → double-press toggles interaction
- [ ] Agent says goodbye → `app_end_interaction` ends the session
- [ ] Disable "Always listen" → mic stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)