### PR TITLE
Dynamic TTS model selection, streaming improvements, WebSocket resilience

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -361,13 +361,13 @@ class APIClient {
   }
 
   /**
-   * List available TTS backends
+   * List available TTS models
    */
-  async listBackends(): Promise<string[]> {
+  async listTTSModels(): Promise<string[]> {
     const response = await this.client.get<BackendsResponse>('/tts/backends', {
       headers: this.getHeaders(),
     });
-    return response.data.backends;
+    return response.data.backends.map((b) => (typeof b === 'string' ? b : b.id));
   }
 
   // ASR Methods

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -8,7 +8,7 @@ import type {
   MessageRawData,
   UserProfile,
   VoicesResponse,
-  BackendsResponse,
+  TTSModelsResponse,
   PullModelResponse,
   TTSRequest,
   Agent,
@@ -364,10 +364,10 @@ class APIClient {
    * List available TTS models
    */
   async listTTSModels(): Promise<string[]> {
-    const response = await this.client.get<BackendsResponse>('/tts/backends', {
+    const response = await this.client.get<TTSModelsResponse>('/tts/models', {
       headers: this.getHeaders(),
     });
-    return response.data.backends.map((b) => (typeof b === 'string' ? b : b.id));
+    return response.data.models.map((m) => (typeof m === 'string' ? m : m.id));
   }
 
   // ASR Methods

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -95,8 +95,15 @@ export interface VoicesResponse {
   voices: string[];
 }
 
+export interface TTSModelInfo {
+  id: string;
+  object?: string;
+  type?: string;
+  loaded?: boolean | null;
+}
+
 export interface BackendsResponse {
-  backends: string[];
+  backends: TTSModelInfo[];
 }
 
 export interface PullModelResponse {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -102,8 +102,8 @@ export interface TTSModelInfo {
   loaded?: boolean | null;
 }
 
-export interface BackendsResponse {
-  backends: TTSModelInfo[];
+export interface TTSModelsResponse {
+  models: TTSModelInfo[];
 }
 
 export interface PullModelResponse {

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -222,6 +222,9 @@ class WebSocketManager {
   private _reconnectAttempt = 0;
   private _maxReconnectDelay = 30000; // 30s cap
   private _intentionalClose = false;
+  private _lastPingTime = 0; // When we last received a server ping
+  private _heartbeatCheckTimer: ReturnType<typeof setInterval> | null = null;
+  private static readonly HEARTBEAT_STALE_MS = 60000; // Expect ping within 60s (server sends every 30s)
 
   /**
    * Set the authentication token.
@@ -276,6 +279,8 @@ class WebSocketManager {
         this.isConnecting = false;
         this._reconnectAttempt = 0;
         this.setStatus('connected');
+        this._lastPingTime = Date.now();
+        this._startHeartbeatCheck();
 
         // Flush queued messages
         for (const msg of this._pendingMessages) {
@@ -295,6 +300,7 @@ class WebSocketManager {
           const data = JSON.parse(event.data);
           // Respond to server heartbeat pings
           if (data.type === 'ping') {
+            this._lastPingTime = Date.now();
             this.ws?.send(JSON.stringify({ type: 'pong' }));
             return;
           }
@@ -314,6 +320,7 @@ class WebSocketManager {
         this.isConnecting = false;
         this.ws = null;
         this.connectionPromise = null;
+        this._stopHeartbeatCheck();
         this.setStatus('disconnected');
 
         if (event.code === 4001) {
@@ -330,6 +337,26 @@ class WebSocketManager {
     });
 
     return this.connectionPromise;
+  }
+
+  private _startHeartbeatCheck() {
+    this._stopHeartbeatCheck();
+    this._heartbeatCheckTimer = setInterval(() => {
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+      const elapsed = Date.now() - this._lastPingTime;
+      if (elapsed > WebSocketManager.HEARTBEAT_STALE_MS) {
+        console.warn(`[WebSocket] No server ping for ${Math.round(elapsed / 1000)}s, connection stale — forcing reconnect`);
+        this._stopHeartbeatCheck();
+        this.ws.close(4000, 'Heartbeat timeout');
+      }
+    }, 15000); // Check every 15s
+  }
+
+  private _stopHeartbeatCheck() {
+    if (this._heartbeatCheckTimer) {
+      clearInterval(this._heartbeatCheckTimer);
+      this._heartbeatCheckTimer = null;
+    }
   }
 
   private _scheduleReconnect() {
@@ -360,6 +387,7 @@ class WebSocketManager {
    */
   disconnect() {
     this._intentionalClose = true;
+    this._stopHeartbeatCheck();
     if (this._reconnectTimer) {
       clearTimeout(this._reconnectTimer);
       this._reconnectTimer = null;

--- a/src/components/SettingsWindow.tsx
+++ b/src/components/SettingsWindow.tsx
@@ -295,13 +295,13 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ onBack }) => {
 
           <Divider sx={{ mb: 3 }} />
 
-          {/* TTS Backend */}
+          {/* TTS Model */}
           <Box sx={{ mb: 3 }}>
             <FormControl fullWidth>
-              <InputLabel>TTS Backend</InputLabel>
+              <InputLabel>TTS Model</InputLabel>
               <Select
                 value={ttsBackend}
-                label="TTS Backend"
+                label="TTS Model"
                 onChange={(e) => setTtsBackend(e.target.value)}
               >
                 {backends.map((backend) => (

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -331,6 +331,7 @@ export const ChatWidget: React.FC<ChatWidgetProps> = ({ characterWindowOpen = fa
           onDelete={streaming.handleDelete}
           searchHighlight={isSearchMatch ? searchQuery : undefined}
           ttsRef={ttsRef}
+          isQueueActive={isQueueActive}
         />
         </Box>
       );

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -86,6 +86,7 @@ interface MessageBubbleProps {
   onDelete?: (messageIndex: number) => void;
   searchHighlight?: string;
   ttsRef: React.RefObject<{ speak: (text: string, voice?: string, language?: string, backend?: string, emotionParams?: { emo_audio?: string; emo_alpha?: number; use_emo_text?: boolean }) => Promise<void>; stopTTS: () => void; isTTSPlaying: boolean; setActiveAgentForTTS: (agentId: number | null) => void }>;
+  isQueueActive?: boolean;
 }
 
 const MessageBubbleComponent: React.FC<MessageBubbleProps> = ({
@@ -106,10 +107,13 @@ const MessageBubbleComponent: React.FC<MessageBubbleProps> = ({
   onDelete,
   searchHighlight,
   ttsRef,
+  isQueueActive,
 }) => {
   const isStreamingThisMessage = isLast && message.role !== 'user' && isStreaming;
   const showFinishedIndicator = isLast && message.role !== 'user' && justFinishedStreaming && !isStreaming;
   const [localPlaying, setLocalPlaying] = useState(false);
+  // Show TTS active on the last assistant bubble during auto-play
+  const autoPlaying = !!(isQueueActive && isLast && message.role !== 'user' && !localPlaying);
 
   // Raw data dialog state
   const [rawDialogOpen, setRawDialogOpen] = useState(false);
@@ -629,7 +633,7 @@ const MessageBubbleComponent: React.FC<MessageBubbleProps> = ({
             hasMessageId={!!message.id}
             hasRawData={!!message.id}
             copied={copied}
-            localPlaying={localPlaying}
+            localPlaying={localPlaying || autoPlaying}
             agentRole={message.role === 'assistant' ? (message.agent?.name || message.name) || undefined : undefined}
             modelName={message.model_name || undefined}
             onCopy={handleCopy}

--- a/src/components/settings/TTSSection.tsx
+++ b/src/components/settings/TTSSection.tsx
@@ -240,13 +240,13 @@ export const TTSSection: React.FC = () => {
 
       <Divider sx={{ mb: 3 }} />
 
-      {/* TTS Backend */}
+      {/* TTS Model */}
       <Box sx={{ mb: 3 }}>
         <FormControl fullWidth>
-          <InputLabel>TTS Backend</InputLabel>
+          <InputLabel>TTS Model</InputLabel>
           <Select
             value={ttsBackend}
-            label="TTS Backend"
+            label="TTS Model"
             onChange={(e) => setTtsBackend(e.target.value)}
           >
             {backends.map((backend) => (

--- a/src/hooks/useStreamingChat.ts
+++ b/src/hooks/useStreamingChat.ts
@@ -399,18 +399,21 @@ export function useStreamingChat({
     }
 
     // Streaming TTS auto-play: feed complete sentences to TTS queue
+    // Only queue when we have full sentences AND enough words (min 10)
     if (storage.getTTSAutoPlay() && event.content && event.role !== 'tool') {
       ttsVoiceRef.current = event.voice_reference || ttsVoiceRef.current;
       ttsBufferRef.current += event.content;
       // Split on sentence-ending punctuation; all but the last segment are complete
-      const parts = ttsBufferRef.current.split(/(?<=[.!?\n])\s*/);
+      const parts = ttsBufferRef.current.split(/(?<=[.!?。！？\n])\s*/);
       if (parts.length > 1) {
-        const batch = parts.slice(0, -1).join(' ');
-        ttsBufferRef.current = parts[parts.length - 1];
-        if (batch.trim()) {
-          const cleaned = stripNarration(batch);
+        const completeSentences = parts.slice(0, -1).join(' ');
+        const wordCount = completeSentences.trim().split(/\s+/).length;
+        if (wordCount >= 10) {
+          ttsBufferRef.current = parts[parts.length - 1];
+          const cleaned = stripNarration(completeSentences);
           if (cleaned) queueText(cleaned, ttsVoiceRef.current);
         }
+        // If < 10 words, keep accumulating — don't update buffer
       }
     }
   }, [setCurrentConversationId, scheduleStreamUpdate, queueText, pushAgentCharacterConfig]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -3,7 +3,7 @@ import { apiClient } from '../api/client';
 import { storage } from '../utils/storage';
 import { useAudioAmplitude } from './useAudioAmplitude';
 
-const TTS_BACKENDS = ['vixtts', 'gpt-sovits'] as const;
+const TTS_FALLBACK_MODELS = ['vixtts', 'gpt-sovits'];
 
 /**
  * Parse WAV header to get audio duration in seconds.
@@ -40,7 +40,7 @@ export function useTTS(
 ) {
   const [isPlaying, setIsPlaying] = useState(false);
   const [voices, setVoices] = useState<string[]>([]);
-  const [backends, setBackends] = useState<string[]>([...TTS_BACKENDS]);
+  const [backends, setBackends] = useState<string[]>([...TTS_FALLBACK_MODELS]);
   const currentAudioRef = useRef<HTMLAudioElement | null>(null);
   const audioUrlRef = useRef<string | null>(null);
 
@@ -68,9 +68,17 @@ export function useTTS(
   }, []);
 
   const loadBackends = useCallback(async () => {
-    const backendList = [...TTS_BACKENDS];
-    setBackends(backendList);
-    return backendList;
+    try {
+      const models = await apiClient.listTTSModels();
+      if (models.length > 0) {
+        setBackends(models);
+        return models;
+      }
+    } catch (error) {
+      console.error('Failed to load TTS models:', error);
+    }
+    setBackends([...TTS_FALLBACK_MODELS]);
+    return [...TTS_FALLBACK_MODELS];
   }, []);
 
   /**

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -3,7 +3,7 @@ import { apiClient } from '../api/client';
 import { storage } from '../utils/storage';
 import { useAudioAmplitude } from './useAudioAmplitude';
 
-const TTS_FALLBACK_MODELS = ['vixtts', 'gpt-sovits'];
+const TTS_FALLBACK_MODELS = ['vixtts', 'gpt-sovits', 'vieneu:turbo'];
 
 /**
  * Parse WAV header to get audio duration in seconds.


### PR DESCRIPTION
## Summary
- **TTS model dropdown**: fetch models from API (`GET /tts/models`) instead of hardcoded list; label renamed "TTS Backend" → "TTS Model"; fallback includes vieneu:turbo
- **Streaming TTS**: add minimum 10-word threshold before queuing chunks; add CJK sentence-ending punctuation to split regex
- **TTS playing indicator**: last assistant bubble shows active TTS button (red stop icon) during streaming auto-play
- **WebSocket resilience**: client-side heartbeat stale detection — if no server ping received for 60s, force-close and auto-reconnect; fixes silent connection death where messages go to dead socket

## Test plan
- [ ] TTS model dropdown shows vixtts, gpt-sovits, vieneu:turbo
- [ ] Short sentences accumulate before TTS (at least 10 words)
- [ ] Last bubble shows red stop icon during auto-play TTS
- [ ] Leave app idle >60s with no server — WebSocket reconnects automatically
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)