### PR TITLE
Add wire-protocol version handshake gate

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,15 +6,32 @@ import { useAuthStore } from './store/authStore';
 import { LoginWindow } from './components/LoginWindow';
 import { MainLayout } from './components/layout/MainLayout';
 import { UpdateDialog } from './components/UpdateDialog';
+import { UpdateRequiredScreen } from './components/UpdateRequiredScreen';
+import { apiClient } from './api/client';
+import { WIRE_PROTOCOL } from './constants';
+import type { ServerVersionInfo } from './api/types';
 // Side-effect import: registers WebSocket listener for client-side MCP servers
 import './services/mcpService';
 
 const MainApp: React.FC = () => {
   const [initializing, setInitializing] = useState(true);
+  const [versionMismatch, setVersionMismatch] = useState<ServerVersionInfo | null>(null);
   const { isAuthenticated, initializeAuth } = useAuthStore();
 
   useEffect(() => {
     const init = async () => {
+      // Wire-protocol handshake. On unreachable backend we proceed (offline launch
+      // still works); only a confirmed mismatch is a hard gate.
+      try {
+        const info = await apiClient.getServerVersion();
+        if (info.wire_protocol !== WIRE_PROTOCOL) {
+          setVersionMismatch(info);
+          setInitializing(false);
+          return;
+        }
+      } catch {
+        // backend unreachable — let the app try to load anyway
+      }
       await initializeAuth();
       setInitializing(false);
     };
@@ -35,6 +52,10 @@ const MainApp: React.FC = () => {
         <CircularProgress size={40} sx={{ color: 'text.secondary' }} />
       </Box>
     );
+  }
+
+  if (versionMismatch) {
+    return <UpdateRequiredScreen info={versionMismatch} />;
   }
 
   return isAuthenticated ? <MainLayout /> : <LoginWindow />;

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,8 +1,10 @@
 import axios, { AxiosInstance } from 'axios';
 import { config } from '../config';
+import { WIRE_PROTOCOL } from '../constants';
 import { wsManager } from './websocket';
 import type {
   LoginResponse,
+  ServerVersionInfo,
   Conversation,
   ConversationDetail,
   MessageRawData,
@@ -42,9 +44,12 @@ class APIClient {
       timeout: 30000,
     });
 
-    // Read baseURL dynamically so it picks up changes from storage
+    // Read baseURL dynamically so it picks up changes from storage, and stamp
+    // every request with the wire-protocol header so backend can reject
+    // incompatible clients with HTTP 426.
     this.client.interceptors.request.use((reqConfig) => {
       reqConfig.baseURL = config.apiBaseUrl;
+      reqConfig.headers.set('X-Wire-Protocol', String(WIRE_PROTOCOL));
       return reqConfig;
     });
 
@@ -138,6 +143,11 @@ class APIClient {
       headers['Authorization'] = `Bearer ${this.token}`;
     }
     return headers;
+  }
+
+  async getServerVersion(): Promise<ServerVersionInfo> {
+    const response = await this.client.get<ServerVersionInfo>('/version');
+    return response.data;
   }
 
   async login(username: string, password: string): Promise<LoginResponse> {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -4,6 +4,11 @@ export interface LoginResponse {
   token_type: string;
 }
 
+export interface ServerVersionInfo {
+  backend_version: string;
+  wire_protocol: number;
+}
+
 // Embedded agent info in messages (subset of Agent)
 export interface MessageAgent {
   id: number;

--- a/src/components/UpdateRequiredScreen.tsx
+++ b/src/components/UpdateRequiredScreen.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Box, Typography, Stack } from '@mui/material';
+import { WIRE_PROTOCOL } from '../constants';
+import type { ServerVersionInfo } from '../api/types';
+
+interface Props {
+  info: ServerVersionInfo;
+  appVersion?: string;
+}
+
+export const UpdateRequiredScreen: React.FC<Props> = ({ info, appVersion }) => (
+  <Box
+    sx={{
+      minHeight: '100vh',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      bgcolor: 'background.default',
+      p: 3,
+    }}
+  >
+    <Stack spacing={1.5} alignItems="center" maxWidth={520} textAlign="center">
+      <Typography variant="h5">Update required</Typography>
+      <Typography variant="body1">
+        This app is incompatible with the server. Please update.
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        App: {appVersion ?? '?'} · wire {WIRE_PROTOCOL}
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        Server: {info.backend_version} · wire {info.wire_protocol}
+      </Typography>
+    </Stack>
+  </Box>
+);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,5 @@
+// Wire-protocol integer — must equal backend `WIRE_PROTOCOL` in
+// KurisuAssistant/kurisuassistant/version.py. Bump on any breaking change to
+// REST/WebSocket payloads, headers, or auth flow. Sent on every request via
+// an axios interceptor and checked once on startup against `GET /version`.
+export const WIRE_PROTOCOL = 1;


### PR DESCRIPTION
## Summary
- Stamps every request with `X-Wire-Protocol` header so backend can reject incompatible clients with HTTP 426
- On startup, fetches `GET /version` and shows a blocking `UpdateRequiredScreen` when the integer doesn't match `WIRE_PROTOCOL` in `src/constants.ts`
- Unreachable backend is **not** a hard gate — app proceeds so offline launches still work; only a confirmed mismatch blocks UI

## Test plan
- [ ] Launch with backend reachable + matching wire protocol → app loads normally
- [ ] Launch with backend unreachable → app loads normally (no blocking screen)
- [ ] Manually set `WIRE_PROTOCOL = 999` in constants.ts and rebuild → confirm UpdateRequiredScreen renders with backend version + wire info
- [ ] Inspect a request in DevTools Network tab → confirm `X-Wire-Protocol: 1` header is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)