### PR TITLE
Rename Windows client to Desktop (Windows + Linux support)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-KurisuAssistant-Client-Windows — desktop client for the KurisuAssistant AI platform. React + Electron + TypeScript + MUI + Framer Motion. Chat interface with streaming responses, TTS, image attachments, conversation management, and animated 2D character video call window.
+KurisuAssistant-Client-Desktop — cross-platform desktop client (Windows + Linux) for the KurisuAssistant AI platform. React + Electron + TypeScript + MUI + Framer Motion. Chat interface with streaming responses, TTS, image attachments, conversation management, and animated 2D character video call window.
 
 ## Tech Stack
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
       {
         "provider": "github",
         "owner": "Khoality-dev",
-        "repo": "KurisuAssistant-Client-Windows",
+        "repo": "KurisuAssistant-Client-Desktop",
         "releaseType": "release"
       }
     ]


### PR DESCRIPTION
## Summary
- Update CLAUDE.md project description to reflect cross-platform (Windows + Linux) scope
- Update electron-builder publish.repo target to the new repo name

## Test plan
- [ ] After merge, rename the GitHub repo to KurisuAssistant-Client-Desktop
- [ ] Confirm electron-updater still works (GitHub redirects old → new for deployed clients)

🤖 Generated with [Claude Code](https://claude.com/claude-code)