### PR TITLE
Add Linux build target (AppImage + deb)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,30 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx vite build && npx electron-builder --publish always
+
+  build-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Set version from release tag
+        run: |
+          version="${{ github.event.release.tag_name }}"
+          version="${version#v}"
+          npm version "$version" --no-git-tag-version
+
+      - name: Build and publish Electron app
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx vite build && npx electron-builder --linux --publish always

--- a/package.json
+++ b/package.json
@@ -86,6 +86,13 @@
         "nsis"
       ]
     },
+    "linux": {
+      "target": [
+        "AppImage",
+        "deb"
+      ],
+      "category": "Network"
+    },
     "publish": [
       {
         "provider": "github",


### PR DESCRIPTION
## Summary
- Add `linux` block to electron-builder config with `AppImage` and `deb` targets, freedesktop category "Network"
- Add `build-linux` job to `.github/workflows/build.yml` that runs on `ubuntu-latest` and publishes Linux artifacts to the same GitHub Release the Windows job uses
- Windows job left untouched to avoid risk to the working pipeline

## Notes
- No Linux icon is configured; electron-builder will fall back to the default Electron icon. Add one in `build/icon.png` (512×512+) for branded artifacts.
- `electron-updater` already supports AppImage out of the box; no client-side changes needed for auto-updates.

## Test plan
- [ ] Cut a test release tag → confirm both Windows (`.exe`) and Linux (`.AppImage`, `.deb`) artifacts attach to the release
- [ ] Install AppImage on a Linux box, verify the app runs and connects to backend
- [ ] Verify `latest-linux.yml` is published (electron-updater needs it for AppImage auto-updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)