### PR TITLE
Fix Linux compatibility blockers (tray, extensions, browser, installer)

### DIFF
--- a/electron/appTools.ts
+++ b/electron/appTools.ts
@@ -471,7 +471,16 @@ function findBrowser(preference: string): { name: string; path: string } | null 
             path.join(process.env['PROGRAMFILES(X86)'] || '', 'Google', 'Chrome', 'Application', 'chrome.exe'),
             path.join(process.env.LOCALAPPDATA || '', 'Google', 'Chrome', 'Application', 'chrome.exe'),
           ]
-        : ['/usr/bin/google-chrome', '/usr/bin/google-chrome-stable', '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'],
+        : [
+            '/usr/bin/google-chrome',
+            '/usr/bin/google-chrome-stable',
+            '/usr/bin/chromium',
+            '/usr/bin/chromium-browser',
+            '/snap/bin/chromium',
+            '/snap/bin/google-chrome',
+            '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+            '/Applications/Chromium.app/Contents/MacOS/Chromium',
+          ],
     },
     {
       name: 'edge',
@@ -480,7 +489,12 @@ function findBrowser(preference: string): { name: string; path: string } | null 
             path.join(process.env.PROGRAMFILES || '', 'Microsoft', 'Edge', 'Application', 'msedge.exe'),
             path.join(process.env['PROGRAMFILES(X86)'] || '', 'Microsoft', 'Edge', 'Application', 'msedge.exe'),
           ]
-        : ['/usr/bin/microsoft-edge', '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'],
+        : [
+            '/usr/bin/microsoft-edge',
+            '/usr/bin/microsoft-edge-stable',
+            '/opt/microsoft/msedge/microsoft-edge',
+            '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+          ],
     },
   ];
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -63,8 +63,10 @@ function initAutoLaunch(): void {
 }
 
 function createTray(): void {
-  // Try to use app icon from resources, fall back to empty
-  const iconPath = path.join(__dirname, '../resources/icon.ico');
+  // Try to use app icon from resources, fall back to empty.
+  // Linux/macOS need PNG; Windows uses .ico.
+  const iconName = process.platform === 'win32' ? 'icon.ico' : 'icon.png';
+  const iconPath = path.join(__dirname, '../resources', iconName);
   const trayIcon = fs.existsSync(iconPath)
     ? nativeImage.createFromPath(iconPath)
     : nativeImage.createEmpty();
@@ -274,14 +276,19 @@ ipcMain.on('character:subtitle', (_event, data) => {
 // --- Extensions ---
 
 function getExtensionExePath(appName: string): string {
-  const localAppData = process.env.LOCALAPPDATA || path.join(app.getPath('home'), 'AppData', 'Local');
-  if (appName === 'maestro') {
-    return path.join(localAppData, 'Programs', 'Maestro', 'Maestro.exe');
+  if (appName !== 'maestro' && appName !== 'chronicle') {
+    throw new Error(`Unknown extension: ${appName}`);
   }
-  if (appName === 'chronicle') {
-    return path.join(localAppData, 'Programs', 'Chronicle', 'Chronicle.exe');
+  const displayName = appName === 'maestro' ? 'Maestro' : 'Chronicle';
+  if (process.platform === 'win32') {
+    const localAppData = process.env.LOCALAPPDATA || path.join(app.getPath('home'), 'AppData', 'Local');
+    return path.join(localAppData, 'Programs', displayName, `${displayName}.exe`);
   }
-  throw new Error(`Unknown extension: ${appName}`);
+  // Linux/macOS: portable layout under XDG data dir. The file likely doesn't
+  // exist (these companion apps are currently Windows-only), which is fine —
+  // the IPC handler checks existence and surfaces "not installed" in the UI.
+  const dataDir = process.env.XDG_DATA_HOME || path.join(app.getPath('home'), '.local', 'share');
+  return path.join(dataDir, 'kurisu-assistant', appName, appName);
 }
 
 function downloadFile(url: string, destPath: string, onProgress: (percent: number) => void): Promise<void> {
@@ -351,7 +358,8 @@ ipcMain.handle('extensions:launch-app', (_event, appName: string) => {
 
 ipcMain.handle('extensions:download-install', async (_event, url: string) => {
   const tempDir = app.getPath('temp');
-  const fileName = url.split('/').pop() || 'installer.exe';
+  const defaultName = process.platform === 'win32' ? 'installer.exe' : 'installer';
+  const fileName = url.split('/').pop() || defaultName;
   const destPath = path.join(tempDir, fileName);
 
   await downloadFile(url, destPath, (percent) => {


### PR DESCRIPTION
## Summary
Audit of the Electron client surfaced three runtime paths that assumed Windows and would crash, silently break, or fail to detect installed software on Linux. This PR fixes the blockers without touching working Windows behavior.

- **Tray icon** (`electron/main.ts`): pick `icon.png` on Linux/macOS, `icon.ico` on Windows. Empty-icon fallback still applies when no asset is shipped.
- **Companion extension paths** (`electron/main.ts`): `getExtensionExePath` now branches on `process.platform`. Linux/macOS resolve to `$XDG_DATA_HOME/kurisu-assistant/<app>/<app>` instead of synthesizing a Windows `%LOCALAPPDATA%` layout. Maestro/Chronicle are currently Windows-only, so on Linux the path won't exist and the existing `fs.existsSync` check correctly reports "not installed" rather than crashing.
- **Browser detection** (`electron/appTools.ts`): added Chromium, `chromium-browser`, snap paths, and `microsoft-edge-stable` to the Linux candidates so CDP launch works on common distros without extra config.
- **Download installer fallback name** (`electron/main.ts`): `installer` (no `.exe`) on non-Windows when the URL has no filename.

## Out of scope (deliberately not in this PR)
- VS Code path caching subtlety in `explorerIPC.ts` (vsCodeAvailable is still queried before exec from the UI side; not a real bug)
- Missing tray icon assets — fallback to empty image is unchanged
- Host-tools sandbox path semantics (already platform-agnostic via `path.resolve`)

## Test plan
- [ ] Build Linux artifact (`electron-builder --linux`) and run AppImage on Ubuntu
- [ ] Verify Settings → Extensions shows Maestro/Chronicle as "not installed" instead of erroring
- [ ] Verify CDP browser launch finds Chromium or Chrome where present
- [ ] Confirm Windows build still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)