### PR TITLE
Run E2E tests on Linux + Windows via matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,11 @@ on:
 
 jobs:
   e2e:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
 
     steps:
@@ -28,14 +32,19 @@ jobs:
       - name: Build renderer + Electron main
         run: npm run test:e2e:build
 
-      - name: Run Playwright tests
+      - name: Run Playwright tests (Linux, under xvfb)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a npm run test:e2e
+
+      - name: Run Playwright tests (Windows)
+        if: runner.os == 'Windows'
         run: npm run test:e2e
 
       - name: Upload test artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-artifacts
+          name: playwright-artifacts-${{ matrix.os }}
           path: |
             test-results/
             playwright-report/

--- a/tests/mock/server.ts
+++ b/tests/mock/server.ts
@@ -196,6 +196,12 @@ export class MockBackend {
       return;
     }
 
+    // Version handshake — must return the wire_protocol the client expects,
+    // otherwise the startup gate in App.tsx blocks the UI with UpdateRequiredScreen.
+    if (pathOnly === '/version' && method === 'GET') {
+      return this.json(res, { backend_version: '0.2.0', wire_protocol: 1 });
+    }
+
     // Auth endpoints
     if (pathOnly === '/login' && method === 'POST') {
       return this.json(res, {


### PR DESCRIPTION
## Summary
- Convert `e2e` job to a `{windows-latest, ubuntu-latest}` matrix
- Linux step wraps `npm run test:e2e` in `xvfb-run -a` (Electron needs a display server; xvfb is preinstalled on `ubuntu-latest`)
- `fail-fast: false` so a single-OS failure doesn't cancel the other leg
- Failure artifacts disambiguated by OS

## Why now
We just added a Linux build target and patched runtime Linux blockers. Running the existing Playwright Electron tests on Linux locks in compatibility — the next regression that creeps in (hardcoded Windows path, missing Linux fallback, etc.) gets caught by CI rather than at release time.

## Test plan
- [ ] PR runs E2E on both Windows and Linux
- [ ] Both legs go green
- [ ] If Linux fails, check whether it's a real bug or test fragility — fix or skip with a `test.skip(process.platform === 'linux', ...)` accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)